### PR TITLE
feat: remove required option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ const parsed = typeFlag({
 ### Usage
 
 #### Default values
-Set a default value with the `default` property. When a default is provided, the flag type will not include `undefined`.
+Set a default value with the `default` property. When a default is provided, the flag type will include that instead of `undefined`.
 
-Pass in a function to return mutable values.
+When using mutable values (eg. objects/arrays) as a default, pass in a function that creates it to avoid mutation-related bugs.
 
 ```ts
 const parsed = typeFlag({

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ const parsed = typeFlag({
 
     someBoolean: {
         type: Boolean,
-        alias: 'b',
-        required: true
+        alias: 'b'
     },
 
     someNumber: {
@@ -68,27 +67,6 @@ const parsed = typeFlag({
 
 ### Usage
 
-#### Required flags
-By default, all flags are optional so the flag type may include `undefined` in case it was not passed in.
-
-Make a flag required by setting `required: true` and TypeFlag will throw when it is not passed in.
-
-```ts
-const parsed = typeFlag({
-    someNumber: {
-        type: Number,
-        required: true
-    }
-})
-```
-
-When a flag is required, the return type will no longer include `undefined`:
-```ts
-{
-    someNumber: number; // No more " | undefined"
-}
-```
-
 #### Default values
 Set a default value with the `default` property. When a default is provided, the flag type will not include `undefined`.
 
@@ -107,8 +85,6 @@ const parsed = typeFlag({
     }
 })
 ```
-
-Note, since a flag with a default value is inherently an optional flag, it is mutually exclusive with the `required` option.
 
 #### kebab-case flags mapped to camelCase
 When passing in the flags, they can be in kebab-case and will automatically map to the camelCase equivalent.
@@ -289,7 +265,7 @@ type FlagSchema = {
     [flagName: string]: TypeFunction | [TypeFunction] | {
         type: TypeFunction | [TypeFunction];
         alias?: string;
-        required?: true;
+        default?: any;
     };
 };
 ```

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -193,11 +193,6 @@ export const validateFlags = <Schemas extends Flags>(
 			}
 
 			flags[flagName] = defaultValue;
-		} else if (
-			('required' in schema)
-			&& schema.required
-		) {
-			throw new Error(`Missing required option "--${flagName}"`);
 		}
 	}
 };

--- a/tests/type-flag.spec.ts
+++ b/tests/type-flag.spec.ts
@@ -122,20 +122,6 @@ describe('Types', () => {
 				type: [String, String],
 				alias: 'a',
 			},
-
-			// @ts-expect-error required can only be true
-			requiredFalse: {
-				type: Boolean,
-				required: false,
-			},
-
-			requiredAndDefault: {
-				type: String,
-				required: true,
-
-				// @ts-expect-error required & default are mutually exclusive
-				default: '',
-			},
 		}, []);
 	});
 
@@ -154,15 +140,14 @@ describe('Types', () => {
 		const parsed = readonly({
 			flagA: {
 				type: String,
-				required: true,
 			},
 			flagB: {
 				type: [String],
-				default: 'world',
+				default: () => ['world'],
 			},
 		}, ['--flag-a', 'hello']);
 
-		expect<string>(parsed.flags.flagA);
+		expect<string | undefined>(parsed.flags.flagA);
 		expect<string[]>(parsed.flags.flagB);
 	});
 });
@@ -374,46 +359,6 @@ describe('Parsing', () => {
 		expect<string[]>(parsed._).toStrictEqual(['world']);
 	});
 
-	describe('Required flag', () => {
-		test('Types and parsing', () => {
-			const parsed = typeFlag({
-				string: {
-					type: String,
-					required: true,
-				},
-				boolean: {
-					type: Boolean,
-					required: true,
-				},
-				number: Number,
-			}, ['--string', 'hello', '--boolean', '--number', '1']);
-
-			expect<string>(parsed.flags.string).toBe('hello');
-			expect<boolean>(parsed.flags.boolean).toBe(true);
-			expect<number | undefined>(parsed.flags.number).toBe(1);
-		});
-
-		test('Throw on missing', () => {
-			expect(() => {
-				typeFlag({
-					flagA: {
-						type: String,
-						required: true,
-					},
-				}, []);
-			}).toThrow(/* 'Missing required option "--flagA"' */);
-
-			expect(() => {
-				typeFlag({
-					flagA: {
-						type: [String],
-						required: true,
-					},
-				}, []);
-			}).toThrow(/* 'Missing required option "--flagA"' */);
-		});
-	});
-
 	describe('Default flag value', () => {
 		test('Types and parsing', () => {
 			const parsed = typeFlag({
@@ -438,12 +383,18 @@ describe('Parsing', () => {
 					type: [String],
 					default: () => ['hello'],
 				},
+
+				inconsistentTypesC: {
+					type: Number,
+					default: 'world',
+				},
 			}, []);
 
 			expect<string>(parsed.flags.string).toBe('hello world');
 			expect<boolean | number>(parsed.flags.inconsistentTypes).toBe(1);
 			expect<boolean | undefined>(parsed.flags.inconsistentTypesB).toBe(undefined);
 			expect<string[]>(parsed.flags.arrayOfStrings).toStrictEqual(['hello']);
+			expect<string | number>(parsed.flags.inconsistentTypesC).toBe('world');
 		});
 	});
 });


### PR DESCRIPTION
## Problem
Thought about the `required` option more, and realized that flags are inherently optional so it would be rare to have a _required_ flag (eg. I don't know any CLI commands that have required flags).

There are cases where flags have required values though, but that is a level of validation I don't want this library to have (and I think it should happen on user-land). If we support this, we will have to support other levels of validation.

## Change
Remove `required` option.

