### PR TITLE
fix: allow arbitrary properties on flag

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ type FlagSchemaBase<TF> = {
 	```
 	*/
 	alias?: string;
-};
+} & Record<PropertyKey, unknown>;
 
 type FlagSchemaDefault<TF, DefaultType = any> = FlagSchemaBase<TF> & {
 	/**


### PR DESCRIPTION
closes https://github.com/privatenumber/cleye/issues/2


This `extend` check was failing when there were extra options on the flag schema:
https://github.com/privatenumber/type-flag/blob/f33ea7a90c862b43bf818f6b5898a99d5684d101/src/types.ts#L80

Interestingly only happens for commands.
