### PR TITLE
feat: support single-character flags

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,10 +75,6 @@ const validateFlagName = (
 		throw new Error(`${errorPrefix} cannot be empty`);
 	}
 
-	if (flagName.length === 1) {
-		throw new Error(`${errorPrefix} must be longer than a character`);
-	}
-
 	const hasReservedCharacter = flagName.match(reservedCharactersPattern);
 	if (hasReservedCharacter) {
 		throw new Error(`${errorPrefix} cannot contain ${stringify(hasReservedCharacter?.[0])}`);
@@ -135,6 +131,10 @@ export const createRegistry = (
 		if ('alias' in schema && typeof schema.alias === 'string') {
 			const { alias } = schema;
 			const errorPrefix = `Flag alias ${stringify(alias)} for flag ${stringify(flagName)}`;
+
+			if (flagName.length === 1) {
+				throw new Error(`${errorPrefix} cannot be defined for a single-character flag`);
+			}
 
 			if (alias.length === 0) {
 				throw new Error(`${errorPrefix} cannot be empty`);

--- a/tests/specs/type-flag.ts
+++ b/tests/specs/type-flag.ts
@@ -13,14 +13,6 @@ export default testSuite(({ describe }) => {
 					}).toThrow(/* 'Invalid flag name: empty' */);
 				});
 
-				test('Single character flag name', () => {
-					expect(() => {
-						typeFlag({
-							i: String,
-						}, []);
-					}).toThrow(/* 'Invalid flag name: single characters are reserved for aliases' */);
-				});
-
 				test('Reserved characters', () => {
 					expect(() => {
 						typeFlag({ 'flag a': String }, []);
@@ -68,6 +60,17 @@ export default testSuite(({ describe }) => {
 							},
 						}, []);
 					}).toThrow(/* 'Empty alias' */);
+				});
+
+				test('Single-character alias', () => {
+					expect(() => {
+						typeFlag({
+							a: {
+								type: String,
+								alias: 'a',
+							},
+						}, []);
+					}).toThrow(/* must not be defined for a single-character flag */);
 				});
 
 				test('Multi-character alias', () => {
@@ -405,6 +408,37 @@ export default testSuite(({ describe }) => {
 
 					expect<string[]>(parsed.flags.alias).toStrictEqual(['', '', 'value']);
 					expect(argv).toStrictEqual([]);
+				});
+
+				test('single-character alias', () => {
+					const argv = ['-x', '1', '-y', '2'];
+					const parsed = typeFlag(
+						{
+							x: Number,
+							y: Number,
+						},
+						argv,
+					);
+
+					expect<number | undefined>(parsed.flags.x).toBe(1);
+					expect<number | undefined>(parsed.flags.y).toBe(2);
+				});
+
+				test('single-character alias grouping', () => {
+					const argv = ['-am', 'hello'];
+					const parsed = typeFlag(
+						{
+							a: Boolean,
+							message: {
+								type: String,
+								alias: 'm',
+							},
+						},
+						argv,
+					);
+
+					expect<boolean | undefined>(parsed.flags.a).toBe(true);
+					expect<string | undefined>(parsed.flags.message).toBe('hello');
 				});
 			});
 


### PR DESCRIPTION
Closes #26

Changes:

- removed the check against 1-character `flagName`s
- added a check against 1-character flags with an alias defined

Tests:

- removed the test making sure 1-character flags were disallowed
- added a test making sure 1-character flag names work
- added a test making sure 1-character flag names can be used in alias groups along with longer flags (`git commit -am hello`)

Note:

I was surprised it was as easy as this. And from playing around it seems that type-flag doesn't seem to care if you use `--` or `-`, for flags of any length. For example `foo --message hello` and `foo -message hello` both seem to work. Likewise `foo -m hello` and `foo --m hello`.

I wasn't sure if this was deliberate, I couldn't find it in the docs. But either way, I wanted to get this in along with test cases so if that is considered a bug, not regressing support for single-character flags would be part of the fix requirements if this goes in first.

Another note:

For this to make its way to cleye, there might be some special-casing needed for the `--help` renderer (to avoid suggesting `--x 1` usage instead of `-x 1` (although both work as noted above)). I can help with that too if you'd like, once this or something like it is published.