### PR TITLE
fix: support single-character flag names

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,33 @@ typeFlag({
 parsed.flags.myFlag // => 'hello'
 ```
 
+#### Single-character flag names
+A flag name can itself be a single character. It matches `-x` but not `--x`.
+
+```ts
+typeFlag({
+    x: Number,
+    y: Number
+})
+
+// $ node ./cli -x 10 -y 20
+parsed.flags.x // => 10
+parsed.flags.y // => 20
+```
+
+Because `--x` is reserved for long flags, you can declare both a single-character and a long-form flag as independent entries — useful when the two forms should behave differently (e.g. `rg`'s `-h` shows short help, `--help` shows full help):
+
+```ts
+typeFlag({
+    h: Boolean,
+    help: Boolean
+})
+```
+
+A single-character flag cannot have an `alias` (it already IS a short flag).
+
+**Single-character names vs aliases:** Both produce short flags that can appear in groups — `-ab`, `-av`, or any mix — regardless of whether each character came from a name or an alias. The difference is where the value lands: a name creates its own key in `flags`, while an alias feeds into the target flag's key. Use a single-character name when the short form IS the flag (`-x`/`-y` coordinates, `-h` vs `--help`); use an alias when `--verbose` and `-v` should set the same value.
+
 #### Default values
 Flags that are not passed in will default to being `undefined`. To set a different default value, use the object syntax and pass in a value as the `default` property. When a default is provided, the return type will reflect that instead of `undefined`.
 

--- a/src/type-flag.ts
+++ b/src/type-flag.ts
@@ -56,6 +56,7 @@ export const typeFlag = <Schemas extends Flags>(
 	argvIterator(argv, {
 		onFlag(name, explicitValue, flagIndex) {
 			const isAlias = flagIndex.length === ALIAS_INDEX_LENGTH;
+			// Long-form requires length > 1; single-char names are exclusive to short-form (-h vs --help)
 			const isValid = isAlias || name.length > 1;
 			const isKnownFlag = isValid && hasOwn(flagRegistry, name);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,10 +65,6 @@ const validateFlagName = (
 		throw new Error(`${errorPrefix} cannot be empty`);
 	}
 
-	if (flagName.length === 1) {
-		throw new Error(`${errorPrefix} must be longer than a character`);
-	}
-
 	const hasReservedCharacter = flagName.match(reservedCharactersPattern);
 	if (hasReservedCharacter) {
 		throw new Error(`${errorPrefix} cannot contain "${hasReservedCharacter?.[0]}"`);
@@ -126,6 +122,10 @@ export const createRegistry = (
 		if ('alias' in schema && typeof schema.alias === 'string') {
 			const { alias } = schema;
 			const errorPrefix = `Flag alias "${alias}" for flag "${flagName}"`;
+
+			if (flagName.length === 1) {
+				throw new Error(`${errorPrefix} cannot be defined for a single-character flag`);
+			}
 
 			if (alias.length === 0) {
 				throw new Error(`${errorPrefix} cannot be empty`);

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -377,6 +377,97 @@ describe('Parsing', () => {
 		expect<string | undefined>(parsed.flags.flagD).toBe('x:y=z');
 	});
 
+	describe('single-character flag names', () => {
+		test('parses string value', () => {
+			const parsed = typeFlag({ x: String }, ['-x', 'hello']);
+			expect<string | undefined>(parsed.flags.x).toBe('hello');
+		});
+
+		test('parses boolean value', () => {
+			const parsed = typeFlag({ v: Boolean }, ['-v']);
+			expect<boolean | undefined>(parsed.flags.v).toBe(true);
+		});
+
+		test('groups with multi-char flag alias', () => {
+			const parsed = typeFlag(
+				{
+					a: Boolean,
+					message: {
+						type: String,
+						alias: 'm',
+					},
+				},
+				['-am', 'hello'],
+			);
+			expect<boolean | undefined>(parsed.flags.a).toBe(true);
+			expect<string | undefined>(parsed.flags.message).toBe('hello');
+		});
+
+		test('-h sets only single-char flag', () => {
+			const parsed = typeFlag({
+				h: Boolean,
+				help: Boolean,
+			}, ['-h']);
+			expect<boolean | undefined>(parsed.flags.h).toBe(true);
+			expect<boolean | undefined>(parsed.flags.help).toBe(undefined);
+		});
+
+		test('--help sets only long flag', () => {
+			const parsed = typeFlag({
+				h: Boolean,
+				help: Boolean,
+			}, ['--help']);
+			expect<boolean | undefined>(parsed.flags.h).toBe(undefined);
+			expect<boolean | undefined>(parsed.flags.help).toBe(true);
+		});
+
+		test('both flags distinguishable', () => {
+			const parsed = typeFlag({
+				h: Boolean,
+				help: Boolean,
+			}, ['-h', '--help']);
+			expect<boolean | undefined>(parsed.flags.h).toBe(true);
+			expect<boolean | undefined>(parsed.flags.help).toBe(true);
+		});
+
+		test('--h does not match single-char flag', () => {
+			const parsed = typeFlag({
+				h: Boolean,
+				help: Boolean,
+			}, ['--h']);
+			expect<boolean | undefined>(parsed.flags.h).toBe(undefined);
+			expect<boolean | undefined>(parsed.flags.help).toBe(undefined);
+			expect(parsed.unknownFlags.h).toStrictEqual([true]);
+		});
+
+		test('uppercase single-char flag', () => {
+			const parsed = typeFlag({ X: String }, ['-X', 'hi']);
+			expect<string | undefined>(parsed.flags.X).toBe('hi');
+		});
+
+		test('inline value with = delimiter', () => {
+			const parsed = typeFlag({ x: String }, ['-x=hello']);
+			expect<string | undefined>(parsed.flags.x).toBe('hello');
+		});
+
+		test('array type collects repeated flags', () => {
+			const parsed = typeFlag({ x: [Number] }, ['-x', '1', '-x', '2']);
+			expect<number[]>(parsed.flags.x).toStrictEqual([1, 2]);
+		});
+
+		test('unknown single-char goes to unknownFlags', () => {
+			const parsed = typeFlag({ x: String }, ['-z', 'foo']);
+			expect<string | undefined>(parsed.flags.x).toBe(undefined);
+			expect(parsed.unknownFlags.z).toStrictEqual([true]);
+			expect(parsed._).toStrictEqual(Object.assign(['foo'], { '--': [] }));
+		});
+
+		test('booleanNegation --no-x matches single-char flag', () => {
+			const parsed = typeFlag({ x: Boolean }, ['--no-x'], { booleanNegation: true });
+			expect<boolean | undefined>(parsed.flags.x).toBe(false);
+		});
+	});
+
 	describe('aliases', () => {
 		test('aliases', () => {
 			const argv = ['-s', 'hello', '-b', 'world', '-1', 'goodbye'];

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -466,6 +466,71 @@ describe('Parsing', () => {
 			const parsed = typeFlag({ x: Boolean }, ['--no-x'], { booleanNegation: true });
 			expect<boolean | undefined>(parsed.flags.x).toBe(false);
 		});
+
+		test('groups two single-char boolean names', () => {
+			const parsed = typeFlag({
+				a: Boolean,
+				b: Boolean,
+			}, ['-ab']);
+			expect<boolean | undefined>(parsed.flags.a).toBe(true);
+			expect<boolean | undefined>(parsed.flags.b).toBe(true);
+			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({});
+		});
+
+		test('groups three single-char boolean names', () => {
+			const parsed = typeFlag({
+				a: Boolean,
+				b: Boolean,
+				c: Boolean,
+			}, ['-abc']);
+			expect<boolean | undefined>(parsed.flags.a).toBe(true);
+			expect<boolean | undefined>(parsed.flags.b).toBe(true);
+			expect<boolean | undefined>(parsed.flags.c).toBe(true);
+			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({});
+		});
+
+		test('last char in group takes next-arg value', () => {
+			const parsed = typeFlag({
+				a: Boolean,
+				x: String,
+			}, ['-ax', 'hello']);
+			expect<boolean | undefined>(parsed.flags.a).toBe(true);
+			expect<string | undefined>(parsed.flags.x).toBe('hello');
+		});
+
+		test('last char in group takes inline = value', () => {
+			const parsed = typeFlag({
+				a: Boolean,
+				x: String,
+			}, ['-ax=hello']);
+			expect<boolean | undefined>(parsed.flags.a).toBe(true);
+			expect<string | undefined>(parsed.flags.x).toBe('hello');
+		});
+
+		test('unknown char in group goes to unknownFlags, known chars still set', () => {
+			const parsed = typeFlag({ a: Boolean }, ['-ab']);
+			expect<boolean | undefined>(parsed.flags.a).toBe(true);
+			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({
+				b: [true],
+			});
+		});
+
+		test('group mixes single-char name, alias, and value-taking flag', () => {
+			const parsed = typeFlag(
+				{
+					a: Boolean,
+					verbose: {
+						type: Boolean,
+						alias: 'v',
+					},
+					x: String,
+				},
+				['-avx', 'hi'],
+			);
+			expect<boolean | undefined>(parsed.flags.a).toBe(true);
+			expect<boolean | undefined>(parsed.flags.verbose).toBe(true);
+			expect<string | undefined>(parsed.flags.x).toBe('hi');
+		});
 	});
 
 	describe('aliases', () => {


### PR DESCRIPTION
Restore #27, accidentally reverted by 0f53ac8.

Allows schemas like `{ x: Number, y: Number }` (coordinates) and `{ h: Boolean, help: Boolean }` to distinguish `-h` from `--help` as independent entries. Single-char names match `-x` but not `--x` — the asymmetry preserves the `-h` / `--help` distinction.