### PR TITLE
feat: add positional arguments helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,16 +319,7 @@ parsed._['--'] // ['--my-flag', 'world']
 
 For `['one', '--', 'two']`, `parsed._.slice()` is `['one', 'two']` and `parsed._['--']` is `['two']`.
 
-If you preserve argv yourself and need to rebuild this shape, use `createPositionalArguments()`. It returns a new array and does not mutate the input.
-
-```ts
-import { createPositionalArguments } from 'type-flag'
-
-const positionals = createPositionalArguments(['one', '--', 'two'])
-
-positionals.slice() // ['one', 'two']
-positionals['--'] // ['two']
-```
+Parser and framework integrations that need to rebuild this shape can use `createPositionalArguments()`; see the API reference below.
 
 ### Value Delimiters
 
@@ -565,7 +556,7 @@ The argv array to parse. If you pass your own array, it is mutated to remove the
 
 ### createPositionalArguments(argv)
 
-Builds the same positional argument shape returned as `parsed._`.
+Builds the same positional argument shape returned as `parsed._`. This is mainly useful for parser or framework integrations that already preserved an argv tail and need to expose type-flag-compatible positionals.
 
 Type:
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,17 @@ parsed._['--'] // ['--my-flag', 'world']
 
 For `['one', '--', 'two']`, `parsed._.slice()` is `['one', 'two']` and `parsed._['--']` is `['two']`.
 
+If you preserve argv yourself and need to rebuild this shape, use `createPositionalArguments()`. It returns a new array and does not mutate the input.
+
+```ts
+import { createPositionalArguments } from 'type-flag'
+
+const positionals = createPositionalArguments(['one', '--', 'two'])
+
+positionals.slice() // ['one', 'two']
+positionals['--'] // ['two']
+```
+
 ### Value Delimiters
 
 The characters `=`, `:`, and `.` delimit a value from a flag.
@@ -551,6 +562,24 @@ Type: `string[]`
 Default: `process.argv.slice(2)`
 
 The argv array to parse. If you pass your own array, it is mutated to remove the parsed flag and its value.
+
+### createPositionalArguments(argv)
+
+Builds the same positional argument shape returned as `parsed._`.
+
+Type:
+
+```ts
+const createPositionalArguments: (argv: readonly string[]) => PositionalArguments
+
+type PositionalArguments = string[] & {
+    '--': string[]
+}
+```
+
+The first `--` token is the delimiter. It is omitted from the returned array, and everything after it is also exposed on `positionals['--']`.
+
+`createPositionalArguments()` does not mutate the input array.
 
 ## Comparison With Other Parsers
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { typeFlag } from './type-flag.ts';
 export { getFlag } from './get-flag.ts';
+export { createPositionalArguments } from './positional-arguments.ts';
 export type {
 	TypeFlag,
 	TypeFlagOptions,

--- a/src/positional-arguments.ts
+++ b/src/positional-arguments.ts
@@ -1,0 +1,25 @@
+import type { PositionalArguments } from './types.ts';
+
+export const createPositionalArguments = (
+	argv: readonly string[],
+): PositionalArguments => {
+	const delimiterIndex = argv.indexOf('--');
+
+	if (delimiterIndex === -1) {
+		return Object.assign(
+			[...argv],
+			{ '--': [] },
+		);
+	}
+
+	const beforeDelimiter = argv.slice(0, delimiterIndex);
+	const afterDelimiter = argv.slice(delimiterIndex + 1);
+
+	return Object.assign(
+		[
+			...beforeDelimiter,
+			...afterDelimiter,
+		],
+		{ '--': afterDelimiter },
+	);
+};

--- a/src/positional-arguments.ts
+++ b/src/positional-arguments.ts
@@ -1,9 +1,10 @@
+import { DOUBLE_DASH } from './argv-iterator.ts';
 import type { PositionalArguments } from './types.ts';
 
 export const createPositionalArguments = (
 	argv: readonly string[],
 ): PositionalArguments => {
-	const delimiterIndex = argv.indexOf('--');
+	const delimiterIndex = argv.indexOf(DOUBLE_DASH);
 
 	if (delimiterIndex === -1) {
 		return Object.assign(

--- a/src/positional-arguments.ts
+++ b/src/positional-arguments.ts
@@ -1,26 +1,34 @@
 import { DOUBLE_DASH } from './argv-iterator.ts';
 import type { PositionalArguments } from './types.ts';
 
+export const createPositionalArgumentsFromParts = (
+	argv: string[],
+	doubleDashArguments: string[],
+): PositionalArguments => Object.assign(
+	argv,
+	{ [DOUBLE_DASH]: doubleDashArguments },
+);
+
 export const createPositionalArguments = (
 	argv: readonly string[],
 ): PositionalArguments => {
 	const delimiterIndex = argv.indexOf(DOUBLE_DASH);
 
 	if (delimiterIndex === -1) {
-		return Object.assign(
+		return createPositionalArgumentsFromParts(
 			[...argv],
-			{ '--': [] },
+			[],
 		);
 	}
 
 	const beforeDelimiter = argv.slice(0, delimiterIndex);
 	const afterDelimiter = argv.slice(delimiterIndex + 1);
 
-	return Object.assign(
+	return createPositionalArgumentsFromParts(
 		[
 			...beforeDelimiter,
 			...afterDelimiter,
 		],
-		{ '--': afterDelimiter },
+		afterDelimiter,
 	);
 };

--- a/src/type-flag.ts
+++ b/src/type-flag.ts
@@ -14,9 +14,8 @@ import {
 	applyParser,
 	finalizeFlags,
 } from './utils.ts';
-import { createPositionalArguments } from './positional-arguments.ts';
+import { createPositionalArgumentsFromParts } from './positional-arguments.ts';
 import {
-	DOUBLE_DASH,
 	ALIAS_INDEX_LENGTH,
 	argvIterator,
 	spliceFromArgv,
@@ -51,7 +50,8 @@ export const typeFlag = <Schemas extends Flags>(
 	const removeArgvs: Index[] = [];
 	const flagRegistry = createRegistry(schemas);
 	const unknownFlags: TypeFlag['unknownFlags'] = {};
-	const positionalArgv: string[] = [];
+	const positionals: string[] = [];
+	let doubleDashArguments: string[] = [];
 
 	argvIterator(argv, {
 		onFlag(name, explicitValue, flagIndex) {
@@ -133,11 +133,12 @@ export const typeFlag = <Schemas extends Flags>(
 				return;
 			}
 
+			positionals.push(...args);
+
 			if (isEoF) {
-				positionalArgv.push(DOUBLE_DASH, ...args);
+				doubleDashArguments = args;
 				argv.splice(index[0]);
 			} else {
-				positionalArgv.push(...args);
 				removeArgvs.push(index);
 			}
 		},
@@ -148,6 +149,6 @@ export const typeFlag = <Schemas extends Flags>(
 	return {
 		flags: finalizeFlags(schemas, flagRegistry),
 		unknownFlags,
-		_: createPositionalArguments(positionalArgv),
+		_: createPositionalArgumentsFromParts(positionals, doubleDashArguments),
 	} as Simplify<TypeFlag<Schemas>>;
 };

--- a/src/type-flag.ts
+++ b/src/type-flag.ts
@@ -14,6 +14,7 @@ import {
 	applyParser,
 	finalizeFlags,
 } from './utils.ts';
+import { createPositionalArguments } from './positional-arguments.ts';
 import {
 	DOUBLE_DASH,
 	ALIAS_INDEX_LENGTH,
@@ -50,8 +51,7 @@ export const typeFlag = <Schemas extends Flags>(
 	const removeArgvs: Index[] = [];
 	const flagRegistry = createRegistry(schemas);
 	const unknownFlags: TypeFlag['unknownFlags'] = {};
-	const _ = [] as unknown as TypeFlag['_'];
-	_[DOUBLE_DASH] = [];
+	const positionalArgv: string[] = [];
 
 	argvIterator(argv, {
 		onFlag(name, explicitValue, flagIndex) {
@@ -133,12 +133,11 @@ export const typeFlag = <Schemas extends Flags>(
 				return;
 			}
 
-			_.push(...args);
-
 			if (isEoF) {
-				_[DOUBLE_DASH] = args;
+				positionalArgv.push(DOUBLE_DASH, ...args);
 				argv.splice(index[0]);
 			} else {
+				positionalArgv.push(...args);
 				removeArgvs.push(index);
 			}
 		},
@@ -149,6 +148,6 @@ export const typeFlag = <Schemas extends Flags>(
 	return {
 		flags: finalizeFlags(schemas, flagRegistry),
 		unknownFlags,
-		_,
+		_: createPositionalArguments(positionalArgv),
 	} as Simplify<TypeFlag<Schemas>>;
 };

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from 'manten';
-import { typeFlag } from '#type-flag';
+import {
+	typeFlag,
+	createPositionalArguments,
+} from '#type-flag';
 
 describe('Parsing', () => {
 	describe('edge-cases', () => {
@@ -167,6 +170,59 @@ describe('Parsing', () => {
 			),
 		);
 		expect<string[]>(argv).toStrictEqual([]);
+	});
+
+	describe('createPositionalArguments', () => {
+		test('returns arguments without a double-dash delimiter', () => {
+			const argv = ['one', 'two'];
+			const parsed = createPositionalArguments(argv);
+
+			expect(parsed).toStrictEqual(
+				Object.assign(
+					['one', 'two'],
+					{ '--': [] },
+				),
+			);
+			expect(Object.prototype.propertyIsEnumerable.call(parsed, '--')).toBe(true);
+			expect(argv).toStrictEqual(['one', 'two']);
+		});
+
+		test('moves post-delimiter arguments into the double-dash property', () => {
+			const argv = ['one', '--', 'two'];
+			const parsed = createPositionalArguments(argv);
+
+			expect(parsed).toStrictEqual(
+				Object.assign(
+					['one', 'two'],
+					{ '--': ['two'] },
+				),
+			);
+			expect(parsed.slice()).toStrictEqual(['one', 'two']);
+			expect(parsed['--']).toStrictEqual(['two']);
+			expect(argv).toStrictEqual(['one', '--', 'two']);
+		});
+
+		test('treats only the first double-dash as the delimiter', () => {
+			const parsed = createPositionalArguments(['one', '--', 'two', '--', 'three']);
+
+			expect(parsed).toStrictEqual(
+				Object.assign(
+					['one', 'two', '--', 'three'],
+					{ '--': ['two', '--', 'three'] },
+				),
+			);
+		});
+
+		test('supports empty argv', () => {
+			const parsed = createPositionalArguments([]);
+
+			expect(parsed).toStrictEqual(
+				Object.assign(
+					[],
+					{ '--': [] },
+				),
+			);
+		});
 	});
 
 	test('strings, booleans, numbers', () => {

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -223,6 +223,19 @@ describe('Parsing', () => {
 				),
 			);
 		});
+
+		test('matches typeFlag positional output', () => {
+			const argvCases = [
+				[],
+				['one', 'two'],
+				['one', '--', 'two'],
+				['one', '--', 'two', '--', 'three'],
+			];
+
+			for (const argv of argvCases) {
+				expect(createPositionalArguments(argv)).toStrictEqual(typeFlag({}, [...argv])._);
+			}
+		});
 	});
 
 	test('strings, booleans, numbers', () => {

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -236,6 +236,39 @@ describe('Parsing', () => {
 				expect(createPositionalArguments(argv)).toStrictEqual(typeFlag({}, [...argv])._);
 			}
 		});
+
+		test('rebuilds positionals from an ignored command tail', () => {
+			const argv = ['--verbose', 'typo', '--', 'after'];
+			let preserveTail = false;
+
+			const parsed = typeFlag(
+				{
+					verbose: Boolean,
+				},
+				argv,
+				{
+					ignore: (type) => {
+						if (preserveTail) {
+							return true;
+						}
+
+						if (type === 'argument') {
+							preserveTail = true;
+							return true;
+						}
+					},
+				},
+			);
+
+			expect<boolean | undefined>(parsed.flags.verbose).toBe(true);
+			expect(argv).toStrictEqual(['typo', '--', 'after']);
+			expect(createPositionalArguments(argv)).toStrictEqual(
+				Object.assign(
+					['typo', 'after'],
+					{ '--': ['after'] },
+				),
+			);
+		});
 	});
 
 	test('strings, booleans, numbers', () => {

--- a/tests/specs/type-flag/types.ts
+++ b/tests/specs/type-flag/types.ts
@@ -2,6 +2,7 @@ import { describe, test } from 'manten';
 import { expectTypeOf } from 'expect-type';
 import {
 	typeFlag,
+	createPositionalArguments,
 	type Flags,
 	type TypeFlag,
 	type TypeFlagOptions,
@@ -414,5 +415,13 @@ describe('Types', () => {
 		expectTypeOf(argv.flags.booleanFlag).toEqualTypeOf<boolean | undefined>();
 		expectTypeOf(argv.flags.booleanFlagDefault).toBeBoolean();
 		expectTypeOf(argv.flags.booleanArray).toEqualTypeOf<boolean[]>();
+	});
+
+	test('createPositionalArguments', () => {
+		const readonlyArgv = ['one', '--', 'two'] as const;
+		const parsed = createPositionalArguments(readonlyArgv);
+
+		expectTypeOf(parsed).toEqualTypeOf<PositionalArguments>();
+		expectTypeOf(parsed['--']).toEqualTypeOf<string[]>();
 	});
 });


### PR DESCRIPTION
- Add `createPositionalArguments()` for rebuilding the same positional shape as `parsed._`
- Share the final positional-result constructor with `typeFlag()` without adding an extra internal scan/copy
- No parser behavior change

## Context

`typeFlag()` returns positional arguments as an array with an extra `['--']` property containing values that appeared after the first `--` delimiter. That shape matters for parser and framework integrations that preserve an argv tail and later need to expose type-flag-compatible positionals.

## Problem

The positional shape is subtle enough to hand-roll incorrectly. In particular, `['one', '--', 'two']` should become an array shaped like `['one', 'two']` with `positionals['--']` equal to `['two']`, while omitting the delimiter itself.

The helper should not become parallel logic, but `typeFlag()` also should not pay for duplicate positional processing on its hot path.

## Changes

- Export `createPositionalArguments(argv)` from the package root
- Keep `typeFlag()` on a one-pass positional collection path
- Share the final positional object construction through an internal helper
- Add a consistency test comparing `createPositionalArguments()` with `typeFlag()` positional output
- Keep the helper non-mutating by accepting `readonly string[]` and returning a new `PositionalArguments`
- Keep README positioning low-level: parser/framework integration API, not a headline feature
