### PR TITLE
feat: add flag schema inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,47 @@ The first `--` token is the delimiter. It is omitted from the returned array, an
 
 `createPositionalArguments()` does not mutate the input array.
 
+### inspectFlags(flagSchema, options)
+
+Inspects the flag names that `typeFlag()` accepts for a schema. This is mainly useful for parser or framework integrations that need to avoid duplicating type-flag's flag recognition rules for conflict checks, suggestions, or help metadata.
+
+Type:
+
+```ts
+const inspectFlags: (
+    flagSchema: Flags,
+    options?: { booleanNegation?: boolean }
+) => InspectedFlag[]
+
+type InspectedFlag = {
+    name: string
+    kebabName: string
+    longNames: string[]
+    alias?: string
+    tokens: string[]
+    negatedTokens: string[]
+    isArray: boolean
+    isBoolean: boolean
+}
+```
+
+Example:
+
+```ts
+const inspected = inspectFlags({
+    getID: String,
+    verbose: {
+        type: Boolean,
+        alias: 'v'
+    }
+}, { booleanNegation: true })
+
+inspected[0].tokens // ['--getID', '--get-id']
+inspected[1].tokens // ['--verbose', '-v', '--no-verbose', '--no-v']
+```
+
+`inspectFlags()` validates the schema with the same flag-name and alias rules used by `typeFlag()`.
+
 ## Comparison With Other Parsers
 
 Choose _type-flag_ when you want a tiny parser whose schema returns the values your app actually uses.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,13 @@ export { typeFlag } from './type-flag.ts';
 export { getFlag } from './get-flag.ts';
 export { flagNameToKebab } from './utils.ts';
 export { createPositionalArguments } from './positional-arguments.ts';
+export { inspectFlags } from './inspect-flags.ts';
 export type {
 	TypeFlag,
 	TypeFlagOptions,
 	Flags,
 	IgnoreFunction,
 	PositionalArguments,
+	InspectFlagsOptions,
+	InspectedFlag,
 } from './types.ts';

--- a/src/inspect-flags.ts
+++ b/src/inspect-flags.ts
@@ -1,0 +1,124 @@
+import type {
+	Flags,
+	InspectedFlag,
+	InspectFlagsOptions,
+} from './types.ts';
+import {
+	flagNameToKebab,
+	getFlagAlias,
+	getFlagLongNames,
+	hasOwn,
+	parseFlagType,
+	setFlag,
+} from './utils.ts';
+
+type FlagInspectionData = {
+	alias?: string;
+	flag: InspectedFlag;
+	parser: unknown;
+	registryNames: string[];
+};
+
+const getNormalTokens = (
+	flagName: string,
+	longNames: string[],
+	alias?: string,
+) => [
+	...longNames.map(longName => `--${longName}`),
+	...(flagName.length === 1 ? [`-${flagName}`] : []),
+	...(alias ? [`-${alias}`] : []),
+];
+
+const inspectFlag = (
+	registry: Record<string, string>,
+	schemas: Flags,
+	flagName: string,
+): FlagInspectionData | undefined => {
+	if (!hasOwn(schemas, flagName)) {
+		return;
+	}
+
+	const schema = schemas[flagName];
+	const longNames = getFlagLongNames(flagName);
+	const alias = getFlagAlias(flagName, schema);
+	const [parser, isArray] = parseFlagType(schema);
+
+	for (const longName of longNames) {
+		setFlag(registry, longName, flagName);
+	}
+
+	if (alias) {
+		setFlag(registry, alias, flagName);
+	}
+
+	const acceptedLongNames = flagName.length === 1 ? [] : longNames;
+
+	return {
+		alias,
+		parser,
+		registryNames: [
+			...longNames,
+			...(alias ? [alias] : []),
+		],
+		flag: {
+			name: flagName,
+			kebabName: flagNameToKebab(flagName),
+			longNames: acceptedLongNames,
+			...(alias ? { alias } : {}),
+			tokens: getNormalTokens(
+				flagName,
+				acceptedLongNames,
+				alias,
+			),
+			negatedTokens: [],
+			isArray,
+			isBoolean: parser === Boolean,
+		},
+	};
+};
+
+const applyBooleanNegation = (
+	registry: Record<string, string>,
+	flags: FlagInspectionData[],
+) => {
+	for (const { flag, parser, registryNames } of flags) {
+		if (parser !== Boolean) {
+			continue;
+		}
+
+		const negatedTokens = registryNames
+			.map(flagName => `no-${flagName}`)
+			.filter(negatedFlagName => !hasOwn(registry, negatedFlagName))
+			.map(negatedFlagName => `--${negatedFlagName}`);
+
+		flag.negatedTokens = negatedTokens;
+		flag.tokens = [
+			...flag.tokens,
+			...negatedTokens,
+		];
+	}
+};
+
+export const inspectFlags = (
+	schemas: Flags,
+	{ booleanNegation }: InspectFlagsOptions = {},
+): InspectedFlag[] => {
+	const registry: Record<string, string> = {};
+	const flags: FlagInspectionData[] = [];
+	for (const flagName in schemas) {
+		if (!hasOwn(schemas, flagName)) {
+			continue;
+		}
+
+		const flag = inspectFlag(registry, schemas, flagName);
+		if (flag) {
+			flags.push(flag);
+		}
+	}
+
+	if (booleanNegation) {
+		applyBooleanNegation(registry, flags);
+	}
+
+	return flags.map(({ flag }) => flag);
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,47 @@ export type PositionalArguments = string[] & {
 	'--': string[];
 };
 
+/**
+ * Options for inspecting the accepted flag surface for a schema.
+ */
+export type InspectFlagsOptions = {
+
+	/**
+	 * Include `--no-<flag>` tokens for boolean flags when they would be parsed as negation.
+	 */
+	booleanNegation?: boolean;
+};
+
+/**
+ * Public metadata describing one schema flag's accepted argv surface.
+ */
+export type InspectedFlag = {
+
+	/** The original schema key and parsed output key. */
+	name: string;
+
+	/** The kebab-case long-form name derived from the schema key. */
+	kebabName: string;
+
+	/** Long-form names accepted after `--`, without the `--` prefix. */
+	longNames: string[];
+
+	/** Single-character short alias accepted after `-`, if one is configured. */
+	alias?: string;
+
+	/** Accepted argv tokens, including prefixes and boolean negation tokens when enabled. */
+	tokens: string[];
+
+	/** Accepted boolean-negation argv tokens, including the `--` prefix. */
+	negatedTokens: string[];
+
+	/** Whether this flag collects multiple values. */
+	isArray: boolean;
+
+	/** Whether this flag uses `Boolean` as its parser. */
+	isBoolean: boolean;
+};
+
 // Infers the type from the default value of a flag schema.
 // Note: Preserves literal types from default functions (e.g., () => 'hello' infers 'hello').
 // Users can widen types explicitly with type assertions (e.g., 'hello' as string).

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,6 +98,46 @@ const validateFlagName = (
 	}
 };
 
+export const getFlagLongNames = (
+	flagName: string,
+) => {
+	validateFlagName(flagName);
+
+	const kebabName = flagNameToKebab(flagName);
+
+	return (
+		flagName === kebabName
+			? [flagName]
+			: [flagName, kebabName]
+	);
+};
+
+export const getFlagAlias = (
+	flagName: string,
+	schema: FlagTypeOrSchema,
+) => {
+	if (!('alias' in schema) || typeof schema.alias !== 'string') {
+		return;
+	}
+
+	const { alias } = schema;
+	const errorPrefix = `Flag alias "${alias}" for flag "${flagName}"`;
+
+	if (flagName.length === 1) {
+		throw new Error(`${errorPrefix} cannot be defined for a single-character flag`);
+	}
+
+	if (alias.length === 0) {
+		throw new Error(`${errorPrefix} cannot be empty`);
+	}
+
+	if (alias.length > 1) {
+		throw new Error(`${errorPrefix} must be a single character`);
+	}
+
+	return alias;
+};
+
 type FlagParsingData = [
 	values: unknown[],
 	parser: TypeFunction,
@@ -109,10 +149,10 @@ type FlagRegistry = {
 	[flagName: string]: FlagParsingData;
 };
 
-const setFlag = (
-	registry: FlagRegistry,
+export const setFlag = <FlagData>(
+	registry: Record<string, FlagData>,
 	flagName: string,
-	data: FlagParsingData,
+	data: FlagData,
 ) => {
 	if (hasOwn(registry, flagName)) {
 		throw new Error(`Duplicate flags named "${flagName}"`);
@@ -130,7 +170,6 @@ export const createRegistry = (
 		if (!hasOwn(schemas, flagName)) {
 			continue;
 		}
-		validateFlagName(flagName);
 
 		const schema = schemas[flagName];
 		const flagData: FlagParsingData = [
@@ -139,29 +178,12 @@ export const createRegistry = (
 			schema,
 		];
 
-		setFlag(registry, flagName, flagData);
-
-		const kebabCasing = flagNameToKebab(flagName);
-		if (flagName !== kebabCasing) {
-			setFlag(registry, kebabCasing, flagData);
+		for (const longName of getFlagLongNames(flagName)) {
+			setFlag(registry, longName, flagData);
 		}
 
-		if ('alias' in schema && typeof schema.alias === 'string') {
-			const { alias } = schema;
-			const errorPrefix = `Flag alias "${alias}" for flag "${flagName}"`;
-
-			if (flagName.length === 1) {
-				throw new Error(`${errorPrefix} cannot be defined for a single-character flag`);
-			}
-
-			if (alias.length === 0) {
-				throw new Error(`${errorPrefix} cannot be empty`);
-			}
-
-			if (alias.length > 1) {
-				throw new Error(`${errorPrefix} must be a single character`);
-			}
-
+		const alias = getFlagAlias(flagName, schema);
+		if (alias) {
 			setFlag(registry, alias, flagData);
 		}
 	}

--- a/tests/specs/type-flag/index.ts
+++ b/tests/specs/type-flag/index.ts
@@ -2,6 +2,7 @@ import { describe } from 'manten';
 
 describe('type-flag', () => {
 	import('./error-handling.ts');
+	import('./inspection.ts');
 	import('./types.ts');
 	import('./parsing.ts');
 });

--- a/tests/specs/type-flag/inspection.ts
+++ b/tests/specs/type-flag/inspection.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect } from 'manten';
+import { inspectFlags } from '#type-flag';
+
+describe('Inspection', () => {
+	test('returns accepted tokens for schema flags', () => {
+		const inspected = inspectFlags(
+			{
+				getID: String,
+				verbose: {
+					type: Boolean,
+					alias: 'v',
+				},
+				tags: [String],
+				x: Boolean,
+			},
+			{ booleanNegation: true },
+		);
+
+		expect(inspected).toStrictEqual([
+			{
+				name: 'getID',
+				kebabName: 'get-id',
+				longNames: ['getID', 'get-id'],
+				tokens: ['--getID', '--get-id'],
+				negatedTokens: [],
+				isArray: false,
+				isBoolean: false,
+			},
+			{
+				name: 'verbose',
+				kebabName: 'verbose',
+				longNames: ['verbose'],
+				alias: 'v',
+				tokens: ['--verbose', '-v', '--no-verbose', '--no-v'],
+				negatedTokens: ['--no-verbose', '--no-v'],
+				isArray: false,
+				isBoolean: true,
+			},
+			{
+				name: 'tags',
+				kebabName: 'tags',
+				longNames: ['tags'],
+				tokens: ['--tags'],
+				negatedTokens: [],
+				isArray: true,
+				isBoolean: false,
+			},
+			{
+				name: 'x',
+				kebabName: 'x',
+				longNames: [],
+				tokens: ['-x', '--no-x'],
+				negatedTokens: ['--no-x'],
+				isArray: false,
+				isBoolean: true,
+			},
+		]);
+	});
+
+	test('omits boolean negation tokens unless enabled', () => {
+		const [inspected] = inspectFlags({
+			verbose: Boolean,
+		});
+
+		expect(inspected?.tokens).toStrictEqual(['--verbose']);
+		expect(inspected?.negatedTokens).toStrictEqual([]);
+	});
+
+	test('does not report negation tokens claimed by explicit flags', () => {
+		const [verbose] = inspectFlags(
+			{
+				verbose: Boolean,
+				noVerbose: Boolean,
+			},
+			{ booleanNegation: true },
+		);
+
+		expect(verbose?.tokens).toStrictEqual(['--verbose']);
+		expect(verbose?.negatedTokens).toStrictEqual([]);
+	});
+
+	test('uses type-flag validation rules', () => {
+		expect(() => {
+			inspectFlags({
+				flagA: String,
+				'flag-a': String,
+			});
+		}).toThrow('Duplicate flags named "flag-a"');
+
+		expect(() => {
+			inspectFlags({
+				verbose: {
+					type: Boolean,
+					alias: 'help',
+				},
+			});
+		}).toThrow('Flag alias "help" for flag "verbose" must be a single character');
+	});
+});

--- a/tests/specs/type-flag/types.ts
+++ b/tests/specs/type-flag/types.ts
@@ -3,11 +3,14 @@ import { expectTypeOf } from 'expect-type';
 import {
 	typeFlag,
 	createPositionalArguments,
+	inspectFlags,
 	type Flags,
 	type TypeFlag,
 	type TypeFlagOptions,
 	type IgnoreFunction,
 	type PositionalArguments,
+	type InspectFlagsOptions,
+	type InspectedFlag,
 } from '#type-flag';
 
 // Test Helpers
@@ -423,5 +426,22 @@ describe('Types', () => {
 
 		expectTypeOf(parsed).toEqualTypeOf<PositionalArguments>();
 		expectTypeOf(parsed['--']).toEqualTypeOf<string[]>();
+	});
+
+	test('inspectFlags', () => {
+		const options: InspectFlagsOptions = {
+			booleanNegation: true,
+		};
+		const inspected = inspectFlags({
+			verbose: {
+				type: Boolean,
+				alias: 'v',
+			},
+		}, options);
+
+		expectTypeOf(options).toEqualTypeOf<InspectFlagsOptions>();
+		expectTypeOf(inspected).toEqualTypeOf<InspectedFlag[]>();
+		expectTypeOf(inspected[0].name).toEqualTypeOf<string>();
+		expectTypeOf(inspected[0].tokens).toEqualTypeOf<string[]>();
 	});
 });


### PR DESCRIPTION
## Context

Cleye needs to reason about the same flag recognition surface that type-flag uses internally for conflict checks, strict-mode suggestions, and help metadata. Today that requires Cleye to reconstruct parser rules for camel/kebab names, aliases, single-character flags, and boolean negation.

This PR proposes the smallest type-flag-side inspection surface for that integration work.

## Changes

- Add `inspectFlags(schema, options?)`
- Export `InspectFlagsOptions` and `InspectedFlag`
- Refactor existing flag-name and alias normalization into shared internal utilities used by both parsing and inspection
- Document the helper as an integration API, not a primary user-facing feature
- Add runtime and type coverage for:
  - camelCase plus acronym kebab names
  - aliases
  - single-character flag names
  - array and boolean metadata
  - boolean negation tokens
  - explicit `no*` flag precedence over negation
  - validation parity with `typeFlag()`

## API Sketch

```ts
const inspected = inspectFlags({
	getID: String,
	verbose: {
		type: Boolean,
		alias: 'v',
	},
}, { booleanNegation: true });

inspected[0].tokens; // ['--getID', '--get-id']
inspected[1].tokens; // ['--verbose', '-v', '--no-verbose', '--no-v']
```

`typeFlag()` does not allocate this metadata during normal parsing. Inspection is opt-in and should remain tree-shakable for consumers that do not import it.

## Follow-Up

If this API shape looks reasonable, the next step is to prototype Cleye against it and measure whether it removes local recognition duplication without growing the emitted bundle.
