### PR TITLE
feat: support Standard Schema as flag types

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,47 @@ const parsed = typeFlag({
 parsed.flags.env // Array<Record<string, string | boolean>>
 ```
 
+### Standard Schema (Zod, Valibot, ArkType)
+
+Any [Standard Schema](https://standardschema.dev) (Zod, Valibot, ArkType, and others) can be used directly as a flag type. type-flag detects the schema, validates the value, and infers the flag type from the schema's output. No wrapper or extra import.
+
+```ts
+import * as z from 'zod'
+import { typeFlag } from 'type-flag'
+
+const parsed = typeFlag({
+    size: z.enum(['small', 'medium', 'large']),
+    port: z.coerce.number(),
+    tags: [z.string()] // wrap in an array to accept multiple
+})
+
+parsed.flags.size // 'small' | 'medium' | 'large' | undefined
+parsed.flags.port // number | undefined
+parsed.flags.tags // string[]
+```
+
+It is library-agnostic, so any compliant schema works the same way:
+
+```ts
+import * as v from 'valibot'
+
+const parsed = typeFlag({
+    mode: v.picklist(['dev', 'prod'])
+})
+
+parsed.flags.mode // 'dev' | 'prod' | undefined
+```
+
+Schemas work everywhere a flag type is accepted, including arrays (`[z.string()]`), `{ type, default }` objects, and [`getFlag`](#getflag). On validation failure, the schema's error message is surfaced. This adds no runtime dependency: the Standard Schema spec is types-only and vendored in.
+
+A few things to keep in mind:
+
+- **Numbers need coercion.** CLI values are always strings, so `z.number()` rejects `"3000"`. Use `z.coerce.number()` (or your library's equivalent), then chain validators like `.int()`, `.min()`, and `.max()`.
+- **For multiple values, wrap the schema in `[ ]`** (as with `tags` above), not `z.array(...)`. A schema that itself outputs an array validates a single CLI token against the array, so it type-checks but throws at runtime. To split one value into an array, use a transform such as `z.string().transform(value => value.split(','))`.
+- **Keep booleans native.** Use `Boolean` rather than a schema for boolean flags, so valueless `--flag`, `--no-flag` negation, and short-flag grouping keep working.
+- **Use type-flag's `default`.** type-flag only runs the parser when a flag is present, so a schema-level `.default()` never fires for an absent flag. Set [`default`](#default-values) on the flag instead.
+- **Schemas must be synchronous.** Flag parsing is synchronous, so an async schema throws.
+
 ### Multiple Values
 
 Wrap a parser function in an array to collect repeated values.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.15",
+		"arktype": "^2.2.0",
 		"clean-pkg-json": "^1.4.2",
 		"expect-type": "^1.3.0",
 		"lintroll": "^1.30.2",
@@ -58,6 +59,8 @@
 		"pkgroll": "^2.27.0",
 		"skills-npm": "^1.0.0",
 		"tsx": "^4.21.0",
-		"typescript": "^5.9.3"
+		"typescript": "^5.9.3",
+		"valibot": "^1.4.1",
+		"zod": "^4.4.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@types/node':
         specifier: ^24.10.15
         version: 24.11.0
+      arktype:
+        specifier: ^2.2.0
+        version: 2.2.0
       clean-pkg-json:
         specifier: ^1.4.2
         version: 1.4.2
@@ -35,6 +38,12 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      valibot:
+        specifier: ^1.4.1
+        version: 1.4.1(typescript@5.9.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   benchmarks:
     devDependencies:
@@ -52,6 +61,12 @@ packages:
 
   '@altano/repository-tools@2.0.1':
     resolution: {integrity: sha512-YE/52CkFtb+YtHPgbWPai7oo5N9AKnMuP5LM+i2AG7G1H2jdYBCO1iDnkDE3dZ3C1MIgckaF+d5PNRulgt0bdw==}
+
+  '@ark/schema@0.56.0':
+    resolution: {integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==}
+
+  '@ark/util@0.56.0':
+    resolution: {integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1017,6 +1032,12 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  arkregex@0.0.5:
+    resolution: {integrity: sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==}
+
+  arktype@2.2.0:
+    resolution: {integrity: sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ==}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -2680,6 +2701,14 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  valibot@1.4.1:
+    resolution: {integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
@@ -2768,8 +2797,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.1.13:
-    resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -2777,6 +2806,12 @@ packages:
 snapshots:
 
   '@altano/repository-tools@2.0.1': {}
+
+  '@ark/schema@0.56.0':
+    dependencies:
+      '@ark/util': 0.56.0
+
+  '@ark/util@0.56.0': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3590,6 +3625,16 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  arkregex@0.0.5:
+    dependencies:
+      '@ark/util': 0.56.0
+
+  arktype@2.2.0:
+    dependencies:
+      '@ark/schema': 0.56.0
+      '@ark/util': 0.56.0
+      arkregex: 0.0.5
+
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -4147,8 +4192,8 @@ snapshots:
       '@babel/parser': 7.28.5
       eslint: 9.39.3(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.1.13
-      zod-validation-error: 4.0.2(zod@4.1.13)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -5810,6 +5855,10 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  valibot@1.4.1(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
@@ -5915,10 +5964,10 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@4.1.13):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.1.13
+      zod: 4.4.3
 
-  zod@4.1.13: {}
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/src/standard-schema.ts
+++ b/src/standard-schema.ts
@@ -1,0 +1,53 @@
+/**
+ * Minimal vendored subset of the Standard Schema spec (https://standardschema.dev), v1.
+ * Types-only; keeps type-flag zero-dependency. Mirrors `@standard-schema/spec`.
+ *
+ * Kept byte-compatible with upstream, which relies on a namespace merged with an
+ * interface of the same name, so the conflicting stylistic rules are disabled here.
+ */
+/* eslint-disable @typescript-eslint/no-namespace -- vendored spec */
+/* eslint-disable @typescript-eslint/consistent-type-definitions -- vendored spec */
+export declare namespace StandardSchemaV1 {
+	export interface Props<Input = unknown, Output = Input> {
+		readonly version: 1;
+		readonly vendor: string;
+		readonly validate: (
+			value: unknown,
+		) => Result<Output> | Promise<Result<Output>>;
+		readonly types?: Types<Input, Output> | undefined;
+	}
+
+	export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+	export interface SuccessResult<Output> {
+		readonly value: Output;
+		readonly issues?: undefined;
+	}
+
+	export interface FailureResult {
+		readonly issues: ReadonlyArray<Issue>;
+	}
+
+	export interface Issue {
+		readonly message: string;
+		readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
+	}
+
+	export interface PathSegment {
+		readonly key: PropertyKey;
+	}
+
+	export interface Types<Input = unknown, Output = Input> {
+		readonly input: Input;
+		readonly output: Output;
+	}
+
+	export type InferOutput<Schema extends StandardSchemaV1> =
+		NonNullable<Schema['~standard']['types']>['output'];
+}
+
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+	readonly '~standard': StandardSchemaV1.Props<Input, Output>;
+}
+/* eslint-enable @typescript-eslint/consistent-type-definitions */
+/* eslint-enable @typescript-eslint/no-namespace */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { StandardSchemaV1 } from './standard-schema.ts';
+
 // Expand the type of a given object to include all its properties.
 export type Simplify<T> = { [Key in keyof T]: T[Key] } & {};
 
@@ -12,16 +14,21 @@ export type Simplify<T> = { [Key in keyof T]: T[Key] } & {};
 export type TypeFunction<ReturnType = unknown> = (...args: any[]) => ReturnType;
 
 /**
+ * The value used to type a flag: a parser function or a Standard Schema.
+ */
+type FlagTypeValue = TypeFunction | StandardSchemaV1;
+
+/**
  * A shorthand for defining a flag's type.
  *
- * - Use a single `TypeFunction` to accept one value.
- * - Use a readonly tuple `[TypeFunction]` to accept multiple values (as an array).
+ * - Use a single `TypeFunction` or Standard Schema to accept one value.
+ * - Use a readonly tuple (e.g. `[TypeFunction]`) to accept multiple values (as an array).
  *
  * @see FlagSchema
  */
 export type FlagType = (
-	TypeFunction
-	| readonly [TypeFunction]
+	FlagTypeValue
+	| readonly [FlagTypeValue]
 );
 
 /**
@@ -116,21 +123,68 @@ type InferDefaultType<
 	: Fallback;
 
 /**
+ * Resolves the output type of a single flag-type element: a parser function's
+ * return type, or a Standard Schema's output type.
+ */
+type InferType<Element> = (
+	Element extends StandardSchemaV1
+		? StandardSchemaV1.InferOutput<Element>
+		: Element extends TypeFunction<infer Return>
+			? Return
+			: never
+);
+
+// Unwrap a `{ type: ... }` flag-schema object to its underlying flag type.
+// `& AnyObject` works around a TS bug where `Readonly<T>` in parameter position
+// breaks conditional matching (see AnyObject above).
+type FlagTypeOf<Flag> = (
+	Flag extends { type: infer Type extends FlagType } & AnyObject ? Type : Flag
+);
+
+/**
  * Infers the final JavaScript type of a flag from its schema.
+ *
+ * `FlagTypeOf` unwraps the `{ type }` object form first, so only the two
+ * underlying shapes (array vs scalar) need matching. `InferType` then resolves
+ * each element whether it is a function or a schema.
  */
 export type InferFlagType<
 	Flag extends FlagTypeOrSchema,
 > = (
-	Flag extends (
-		readonly [TypeFunction<infer T>]
-		| { type: readonly [TypeFunction<infer T>] } & AnyObject
-	)
-		? (T[] | InferDefaultType<Flag, never>)
-		: Flag extends TypeFunction<infer T> | ({ type: TypeFunction<infer T> } & AnyObject)
-			// Tuple trick: [T] extends [never] prevents distributive conditional types,
-			// preserving never instead of widening to undefined
-			? ([T] extends [never] ? T : (T | InferDefaultType<Flag, undefined>))
-			: never
+	FlagTypeOf<Flag> extends readonly [infer Element extends FlagTypeValue]
+		? InferArrayType<Flag, Element>
+		: FlagTypeOf<Flag> extends infer Element extends FlagTypeValue
+			? InferScalarType<Flag, Element>
+			// Falls through for an untyped `Flags` index signature (a union that
+			// matches neither shape), where the flag type is `unknown`.
+			: unknown
+);
+
+// `InferType<Element> extends infer Output` forces the output type to resolve
+// before it is unioned with the default, so e.g. `string[] | string[]` collapses
+// to `string[]` instead of lingering as an un-reduced union.
+type InferArrayType<
+	Flag extends FlagTypeOrSchema,
+	Element,
+> = (
+	InferType<Element> extends infer Output
+		? (Output[] | InferDefaultType<Flag, never>)
+		: never
+);
+
+// The `[Output] extends [never]` tuple trick prevents distributive conditional
+// types, preserving `never` instead of widening it to `undefined`.
+type InferScalarType<
+	Flag extends FlagTypeOrSchema,
+	Element,
+> = (
+	InferType<Element> extends infer Output
+		? (
+			[Output] extends [never]
+				? Output
+				: (Output | InferDefaultType<Flag, undefined>)
+		)
+		: never
 );
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import type {
 	Flags,
 	FlagSchema,
 } from './types.ts';
+import type { StandardSchemaV1 } from './standard-schema.ts';
 
 const camelCasePattern = /\B([A-Z])/g;
 const camelToKebab = (string: string) => string.replaceAll(camelCasePattern, '-$1').toLowerCase();
@@ -14,15 +15,54 @@ export const hasOwn = (
 	property: PropertyKey,
 ) => hasOwnProperty.call(object, property);
 
+const isStandardSchema = (
+	value: unknown,
+): value is StandardSchemaV1 => (
+	// Some schemas (e.g. ArkType) are callable, so check functions too
+	(typeof value === 'object' || typeof value === 'function')
+	&& value !== null
+	&& '~standard' in value
+);
+
+/**
+ * Adapt a Standard Schema (Zod, Valibot, ArkType, ...) into a parser function.
+ *
+ * Flag parsing is synchronous, so schemas that validate asynchronously throw.
+ * On validation failure, throws the first issue's message.
+ */
+const schemaToParser = (
+	schema: StandardSchemaV1,
+): TypeFunction => (
+	(value: string) => {
+		const result = schema['~standard'].validate(value);
+
+		if (result instanceof Promise) {
+			throw new TypeError('Async schemas are not supported');
+		}
+
+		if (result.issues) {
+			throw new Error(result.issues[0]?.message ?? 'Validation failed');
+		}
+
+		return result.value;
+	}
+);
+
 export const parseFlagType = (
 	flagSchema: FlagTypeOrSchema,
 ): [parser: TypeFunction, isArray: boolean] => {
+	// Must run before the function check: callable schemas (e.g. ArkType) are
+	// functions, but should validate via `~standard`, not be used as raw parsers.
+	if (isStandardSchema(flagSchema)) {
+		return [schemaToParser(flagSchema), false];
+	}
+
 	if (typeof flagSchema === 'function') {
 		return [flagSchema, false];
 	}
 
 	if (Array.isArray(flagSchema)) {
-		return [flagSchema[0], true];
+		return [parseFlagType(flagSchema[0])[0], true];
 	}
 
 	return parseFlagType((flagSchema as FlagSchema).type);
@@ -156,6 +196,9 @@ export const finalizeFlags = (
 		const [values, , isArray, schema] = registry[flagName];
 		if (
 			values.length === 0
+			// A raw schema (e.g. Zod, ArkType) can have its own `.default`; only a
+			// flag-schema object's `default` is a type-flag default.
+			&& !isStandardSchema(schema)
 			&& 'default' in schema
 		) {
 			let { default: defaultValue } = schema;

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -3,4 +3,5 @@ import { describe } from 'manten';
 describe('type-flag', () => {
 	import('./specs/type-flag/index.ts');
 	import('./specs/get-flag/index.ts');
+	import('./specs/standard-schema.ts');
 });

--- a/tests/specs/standard-schema.ts
+++ b/tests/specs/standard-schema.ts
@@ -1,0 +1,300 @@
+import { describe, test, expect } from 'manten';
+import { expectTypeOf } from 'expect-type';
+import * as z from 'zod';
+import * as v from 'valibot';
+import { type } from 'arktype';
+import { typeFlag, getFlag } from '#type-flag';
+
+describe('standard-schema', () => {
+	describe('Zod', () => {
+		test('enum returns the matched value', () => {
+			const parsed = typeFlag({
+				size: z.enum(['small', 'medium', 'large']),
+			}, ['--size', 'medium']);
+
+			expect(parsed.flags.size).toBe('medium');
+			expectTypeOf(parsed.flags.size).toEqualTypeOf<'small' | 'medium' | 'large' | undefined>();
+		});
+
+		test('enum rejects an invalid value', () => {
+			let thrown: unknown;
+			try {
+				typeFlag({
+					size: z.enum(['small', 'medium', 'large']),
+				}, ['--size', 'huge']);
+			} catch (error) {
+				thrown = error;
+			}
+
+			// The schema's validation message surfaces (flag-name wrapping is a 5.x feature)
+			expect(thrown).toBeInstanceOf(Error);
+			expect((thrown as Error).message).toMatch('Invalid option');
+		});
+
+		test('coerced number validates the range', () => {
+			const parsed = typeFlag({
+				port: z.coerce.number().int().min(1).max(65_535),
+			}, ['--port', '8080']);
+
+			expect(parsed.flags.port).toBe(8080);
+			expectTypeOf(parsed.flags.port).toEqualTypeOf<number | undefined>();
+		});
+
+		test('coerced number rejects out-of-range values', () => {
+			expect(() => {
+				typeFlag({
+					port: z.coerce.number().int().min(1).max(65_535),
+				}, ['--port', '99999']);
+			}).toThrow('Too big');
+		});
+
+		test('non-coerced number rejects a string value', () => {
+			// The CLI value is always a string, so a plain number schema rejects it
+			expect(() => {
+				typeFlag({
+					port: z.number(),
+				}, ['--port', '3000']);
+			}).toThrow('expected number');
+		});
+
+		test('transform maps the value', () => {
+			const parsed = typeFlag({
+				list: z.string().transform(value => value.split(',')),
+			}, ['--list', 'a,b,c']);
+
+			expect(parsed.flags.list).toStrictEqual(['a', 'b', 'c']);
+			expectTypeOf(parsed.flags.list).toEqualTypeOf<string[] | undefined>();
+		});
+
+		test('repeated flag collects and validates each element', () => {
+			const parsed = typeFlag({
+				tag: [z.enum(['debug', 'info', 'warn'])],
+			}, ['--tag', 'debug', '--tag', 'warn']);
+
+			expect(parsed.flags.tag).toStrictEqual(['debug', 'warn']);
+			expectTypeOf(parsed.flags.tag).toEqualTypeOf<('debug' | 'info' | 'warn')[]>();
+		});
+
+		test('repeated flag rejects an invalid element', () => {
+			expect(() => {
+				typeFlag({
+					tag: [z.enum(['debug', 'info', 'warn'])],
+				}, ['--tag', 'debug', '--tag', 'nope']);
+			}).toThrow('Invalid option');
+		});
+
+		test('type-flag default applies when the flag is absent', () => {
+			const parsed = typeFlag({
+				size: {
+					type: z.enum(['small', 'large']),
+
+					// `as const` preserves the literal union; a plain default widens to string
+					default: 'small' as const,
+				},
+			}, []);
+
+			expect(parsed.flags.size).toBe('small');
+			expectTypeOf(parsed.flags.size).toEqualTypeOf<'small' | 'large'>();
+		});
+
+		test('absent raw schema flag is undefined (schema .default is not a type-flag default)', () => {
+			const parsed = typeFlag({
+				size: z.enum(['small', 'large']),
+			}, []);
+
+			expect(parsed.flags.size).toBe(undefined);
+			expectTypeOf(parsed.flags.size).toEqualTypeOf<'small' | 'large' | undefined>();
+		});
+
+		test('{ type } object form behaves like the bare schema', () => {
+			const parsed = typeFlag({
+				size: {
+					type: z.enum(['small', 'large']),
+				},
+			}, ['--size', 'small']);
+
+			expect(parsed.flags.size).toBe('small');
+			expectTypeOf(parsed.flags.size).toEqualTypeOf<'small' | 'large' | undefined>();
+		});
+
+		test('{ type: [schema] } object form collects an array', () => {
+			const parsed = typeFlag({
+				tags: {
+					type: [z.string()],
+				},
+			}, ['--tags', 'a', '--tags', 'b']);
+
+			expect(parsed.flags.tags).toStrictEqual(['a', 'b']);
+			expectTypeOf(parsed.flags.tags).toEqualTypeOf<string[]>();
+		});
+
+		test('array schema with a default falls back to the default and stays a clean array', () => {
+			const parsed = typeFlag({
+				tags: {
+					type: [z.string()],
+					default: () => ['x'],
+				},
+			}, []);
+
+			expect(parsed.flags.tags).toStrictEqual(['x']);
+
+			// Guards against the default unioning into an un-reduced `string[] | string[]`
+			expectTypeOf(parsed.flags.tags).toEqualTypeOf<string[]>();
+		});
+	});
+
+	// Proves the adapter is library-agnostic, not coupled to Zod
+	describe('Valibot', () => {
+		test('picklist returns the matched value', () => {
+			const parsed = typeFlag({
+				mode: v.picklist(['dev', 'prod']),
+			}, ['--mode', 'dev']);
+
+			expect(parsed.flags.mode).toBe('dev');
+			expectTypeOf(parsed.flags.mode).toEqualTypeOf<'dev' | 'prod' | undefined>();
+		});
+
+		test('picklist rejects an invalid value', () => {
+			expect(() => {
+				typeFlag({
+					mode: v.picklist(['dev', 'prod']),
+				}, ['--mode', 'staging']);
+			}).toThrow('Invalid type');
+		});
+
+		test('email validates the string', () => {
+			const parsed = typeFlag({
+				email: v.pipe(v.string(), v.email()),
+			}, ['--email', 'user@example.com']);
+
+			expect(parsed.flags.email).toBe('user@example.com');
+			expectTypeOf(parsed.flags.email).toEqualTypeOf<string | undefined>();
+		});
+
+		test('email rejects an invalid string', () => {
+			expect(() => {
+				typeFlag({
+					email: v.pipe(v.string(), v.email()),
+				}, ['--email', 'not-an-email']);
+			}).toThrow('Invalid email');
+		});
+	});
+
+	// ArkType schemas are callable (typeof === 'function') yet implement Standard
+	// Schema, so they must still route through validation, not the raw-parser path.
+	describe('ArkType (callable schema)', () => {
+		test('returns the matched value', () => {
+			const parsed = typeFlag({
+				size: type("'small' | 'large'"),
+			}, ['--size', 'small']);
+
+			expect(parsed.flags.size).toBe('small');
+			expectTypeOf(parsed.flags.size).toEqualTypeOf<'small' | 'large' | undefined>();
+		});
+
+		test('rejects an invalid value', () => {
+			expect(() => {
+				typeFlag({
+					size: type("'small' | 'large'"),
+				}, ['--size', 'huge']);
+			}).toThrow('must be');
+		});
+
+		test('absent flag is undefined (callable schema is not treated as a default)', () => {
+			const parsed = typeFlag({
+				size: type("'small' | 'large'"),
+			}, []);
+
+			expect(parsed.flags.size).toBe(undefined);
+		});
+	});
+
+	describe('getFlag', () => {
+		test('parses and validates with a schema', () => {
+			const size = getFlag('--size', z.enum(['small', 'large']), ['--size', 'small']);
+
+			expect(size).toBe('small');
+			expectTypeOf(size).toEqualTypeOf<'small' | 'large' | undefined>();
+		});
+
+		test('rejects an invalid value', () => {
+			expect(() => {
+				getFlag('--size', z.enum(['small', 'large']), ['--size', 'huge']);
+			}).toThrow('Invalid option');
+		});
+
+		test('collects an array from a wrapped schema', () => {
+			const tags = getFlag('--tag', [z.string()], ['--tag', 'a', '--tag', 'b']);
+
+			expect(tags).toStrictEqual(['a', 'b']);
+			expectTypeOf(tags).toEqualTypeOf<string[]>();
+		});
+	});
+
+	describe('Async', () => {
+		test('async validation throws (parsing is synchronous)', () => {
+			// Hand-rolled Standard Schema with an async `validate`; no dependency needed
+			const asyncSchema = {
+				'~standard': {
+					version: 1 as const,
+					vendor: 'test',
+					validate: () => Promise.resolve({ value: 'async' }),
+				},
+			};
+
+			expect(() => {
+				typeFlag({
+					asyncFlag: asyncSchema,
+				}, ['--async-flag', 'value']);
+			}).toThrow('Async schemas are not supported');
+		});
+	});
+
+	describe('Inference', () => {
+		test('schema and native flags infer independently in one call', () => {
+			const parsed = typeFlag({
+				schemaEnum: z.enum(['a', 'b']),
+				nativeBoolean: Boolean,
+				nativeString: String,
+				schemaArray: [z.coerce.number()],
+				schemaDefault: {
+					type: z.enum(['x', 'y']),
+					default: 'x' as const,
+				},
+			}, ['--schema-enum', 'a', '--native-boolean', '--native-string', 'hi', '--schema-array', '3']);
+
+			expect(parsed.flags.schemaEnum).toBe('a');
+			expect(parsed.flags.nativeBoolean).toBe(true);
+			expect(parsed.flags.schemaArray).toStrictEqual([3]);
+			expect(parsed.flags.schemaDefault).toBe('x');
+
+			expectTypeOf(parsed.flags).toEqualTypeOf<{
+				schemaEnum: 'a' | 'b' | undefined;
+				nativeBoolean: boolean | undefined;
+				nativeString: string | undefined;
+				schemaArray: number[];
+				schemaDefault: 'x' | 'y';
+			}>();
+		});
+
+		test('a schema whose output is an array is treated as a scalar', () => {
+			// Documented gotcha: `z.array(...)` validates a single token, so use `[schema]`
+			// to accept multiple. At runtime it rejects the token; the type is the output.
+			const schemas = {
+				tags: z.array(z.string()),
+			};
+
+			expect(() => typeFlag(schemas, ['--tags', 'a'])).toThrow('expected array');
+
+			const parsed = typeFlag(schemas, []);
+			expectTypeOf(parsed.flags.tags).toEqualTypeOf<string[] | undefined>();
+		});
+
+		test('rejects a multi-element schema tuple', () => {
+			typeFlag({
+				// @ts-expect-error only one element is allowed in the array form
+				tags: [z.string(), z.string()],
+			}, []);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Any [Standard Schema](https://standardschema.dev) (Zod, Valibot, ArkType, ...) can be used **directly** as a flag type — no wrapper, no extra import. type-flag detects the schema, validates the value, and infers the flag type from the schema's output. Zero runtime dependency (the ~30-line spec is vendored, types-only).

```ts
import * as z from 'zod'
import { typeFlag } from 'type-flag'

const parsed = typeFlag({
    size: z.enum(['small', 'medium', 'large']),
    port: z.coerce.number(),
    tags: [z.string()], // wrap in an array to accept multiple
})

parsed.flags.size // 'small' | 'medium' | 'large' | undefined
parsed.flags.port // number | undefined
parsed.flags.tags // string[]
```

Works everywhere a flag type is accepted: arrays (`[schema]`), `{ type, default }` objects, and `getFlag`. Additive and non-breaking.

## How it works

- **Runtime** (`src/utils.ts`): `parseFlagType` detects a Standard Schema (`'~standard' in value`, incl. callable schemas like ArkType — checked before the function-parser branch) and adapts it via the spec's `validate()`. Async schemas throw (parsing is synchronous). `finalizeFlags` ignores a raw schema's own `.default` so an absent flag is `undefined`. Both `typeFlag` and `getFlag` route through `parseFlagType`.
- **Types** (`src/types.ts`): `FlagType` admits `StandardSchemaV1`; `InferFlagType` resolves a flag by shape (`FlagTypeOf` unwraps `{ type }`) and maps each element to its output via `InferType`. `StandardSchemaV1` is reachable implicitly through `Flags`/`FlagType`, not exported by name.
- **Spec** (`src/standard-schema.ts`): vendored Standard Schema v1 types only.

## Error messages on 4.x

This targets `develop` (4.x), which does **not** have beta's `applyParser` error-wrapping (`a687dc1`, marked `BREAKING CHANGE`). So schema validation errors surface as the **raw schema message** here, not `Flag "--<name>": …`. That wrapping is intentionally a 5.0 change; when `develop` flows up to `beta` the errors get wrapped automatically. Tests therefore assert the schema's message, not the flag-name prefix.

## Tests

`tests/specs/standard-schema.ts` covers Zod + Valibot + ArkType (enum/coerce/transform/repeated/default/email/callable), `getFlag`, the async guard, the `z.array()` footgun, mixed schema+native inference, and type inference (`expectTypeOf`). zod/valibot/arktype are devDependencies only.

Verified locally: `pnpm test` (154 passed) on current Node **and Node 18.20.3** (the CI floor), `pnpm type-check` clean, `pnpm build` ok, `pnpm lint` 0 errors.

## Related

Companion to #66 (the same feature targeted at `beta`, which already has the error-wrapping). #66 stays open as the reference for the eventual `develop` → `beta` merge-up.
