### PR TITLE
feat: export isStandardSchema and StandardSchemaV1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { typeFlag } from './type-flag.ts';
 export { getFlag } from './get-flag.ts';
 export { createPositionalArguments } from './positional-arguments.ts';
+export { isStandardSchema } from './standard-schema.ts';
 export type {
 	TypeFlag,
 	TypeFlagOptions,
@@ -8,3 +9,4 @@ export type {
 	IgnoreFunction,
 	PositionalArguments,
 } from './types.ts';
+export type { StandardSchemaV1 } from './standard-schema.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { typeFlag } from './type-flag.ts';
 export { getFlag } from './get-flag.ts';
 export { createPositionalArguments } from './positional-arguments.ts';
-export { isStandardSchema } from './standard-schema.ts';
+export { isStandardSchema, type StandardSchemaV1 } from './standard-schema.ts';
 export type {
 	TypeFlag,
 	TypeFlagOptions,
@@ -9,4 +9,3 @@ export type {
 	IgnoreFunction,
 	PositionalArguments,
 } from './types.ts';
-export type { StandardSchemaV1 } from './standard-schema.ts';

--- a/src/standard-schema.ts
+++ b/src/standard-schema.ts
@@ -1,9 +1,15 @@
 /**
- * Minimal vendored subset of the Standard Schema spec (https://standardschema.dev), v1.
- * Types-only; keeps type-flag zero-dependency. Mirrors `@standard-schema/spec`.
- *
- * Kept byte-compatible with upstream, which relies on a namespace merged with an
- * interface of the same name, so the conflicting stylistic rules are disabled here.
+ * Standard Schema (https://standardschema.dev) support: the vendored v1 spec
+ * types plus the runtime helpers type-flag uses to detect and adapt schemas.
+ * The spec is vendored rather than depended on to keep type-flag zero-dependency.
+ */
+import type { TypeFunction } from './types.ts';
+
+/**
+ * Minimal vendored subset of the Standard Schema spec, v1. Mirrors
+ * `@standard-schema/spec`. Kept byte-compatible with upstream, which relies on a
+ * namespace merged with an interface of the same name, so the conflicting
+ * stylistic rules are disabled here.
  */
 /* eslint-disable @typescript-eslint/no-namespace -- vendored spec */
 /* eslint-disable @typescript-eslint/consistent-type-definitions -- vendored spec */
@@ -51,3 +57,41 @@ export interface StandardSchemaV1<Input = unknown, Output = Input> {
 }
 /* eslint-enable @typescript-eslint/consistent-type-definitions */
 /* eslint-enable @typescript-eslint/no-namespace */
+
+/**
+ * Detect a Standard Schema (Zod, Valibot, ArkType, ...). Used to accept schemas
+ * directly as flag types, and exported so tools built on type-flag can apply the
+ * same check when introspecting flag definitions.
+ */
+export const isStandardSchema = (
+	value: unknown,
+): value is StandardSchemaV1 => (
+	// Some schemas (e.g. ArkType) are callable, so check functions too
+	(typeof value === 'object' || typeof value === 'function')
+	&& value !== null
+	&& '~standard' in value
+);
+
+/**
+ * Adapt a Standard Schema (Zod, Valibot, ArkType, ...) into a parser function.
+ *
+ * Flag parsing is synchronous, so schemas that validate asynchronously throw.
+ * On validation failure, throws the first issue's message.
+ */
+export const schemaToParser = (
+	schema: StandardSchemaV1,
+): TypeFunction => (
+	(value: string) => {
+		const result = schema['~standard'].validate(value);
+
+		if (result instanceof Promise) {
+			throw new TypeError('Async schemas are not supported');
+		}
+
+		if (result.issues) {
+			throw new Error(result.issues[0]?.message ?? 'Validation failed');
+		}
+
+		return result.value;
+	}
+);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import type {
 	Flags,
 	FlagSchema,
 } from './types.ts';
-import type { StandardSchemaV1 } from './standard-schema.ts';
+import { isStandardSchema, schemaToParser } from './standard-schema.ts';
 
 const camelCasePattern = /\B([A-Z])/g;
 const camelToKebab = (string: string) => string.replaceAll(camelCasePattern, '-$1').toLowerCase();
@@ -14,39 +14,6 @@ export const hasOwn = (
 	object: unknown,
 	property: PropertyKey,
 ) => hasOwnProperty.call(object, property);
-
-const isStandardSchema = (
-	value: unknown,
-): value is StandardSchemaV1 => (
-	// Some schemas (e.g. ArkType) are callable, so check functions too
-	(typeof value === 'object' || typeof value === 'function')
-	&& value !== null
-	&& '~standard' in value
-);
-
-/**
- * Adapt a Standard Schema (Zod, Valibot, ArkType, ...) into a parser function.
- *
- * Flag parsing is synchronous, so schemas that validate asynchronously throw.
- * On validation failure, throws the first issue's message.
- */
-const schemaToParser = (
-	schema: StandardSchemaV1,
-): TypeFunction => (
-	(value: string) => {
-		const result = schema['~standard'].validate(value);
-
-		if (result instanceof Promise) {
-			throw new TypeError('Async schemas are not supported');
-		}
-
-		if (result.issues) {
-			throw new Error(result.issues[0]?.message ?? 'Validation failed');
-		}
-
-		return result.value;
-	}
-);
 
 export const parseFlagType = (
 	flagSchema: FlagTypeOrSchema,

--- a/tests/specs/standard-schema.ts
+++ b/tests/specs/standard-schema.ts
@@ -3,7 +3,12 @@ import { expectTypeOf } from 'expect-type';
 import * as z from 'zod';
 import * as v from 'valibot';
 import { type } from 'arktype';
-import { typeFlag, getFlag } from '#type-flag';
+import {
+	typeFlag,
+	getFlag,
+	isStandardSchema,
+	type StandardSchemaV1,
+} from '#type-flag';
 
 describe('standard-schema', () => {
 	describe('Zod', () => {
@@ -295,6 +300,34 @@ describe('standard-schema', () => {
 				// @ts-expect-error only one element is allowed in the array form
 				tags: [z.string(), z.string()],
 			}, []);
+		});
+	});
+
+	describe('isStandardSchema', () => {
+		test('detects schemas (Zod, Valibot, ArkType)', () => {
+			expect(isStandardSchema(z.string())).toBe(true);
+			expect(isStandardSchema(v.string())).toBe(true);
+			// ArkType schemas are callable, exercising the function branch
+			expect(isStandardSchema(type('string'))).toBe(true);
+		});
+
+		test('rejects parser functions, plain objects, and primitives', () => {
+			expect(isStandardSchema((value: string) => value)).toBe(false);
+			expect(isStandardSchema(String)).toBe(false);
+			expect(isStandardSchema({ type: String })).toBe(false);
+			expect(isStandardSchema(null)).toBe(false);
+			expect(isStandardSchema(undefined)).toBe(false);
+			expect(isStandardSchema('string')).toBe(false);
+		});
+
+		test('StandardSchemaV1 type and InferOutput are exported and usable', () => {
+			const sizeSchema = z.enum(['small', 'large']);
+			expectTypeOf<StandardSchemaV1.InferOutput<typeof sizeSchema>>().toEqualTypeOf<'small' | 'large'>();
+
+			const value: unknown = sizeSchema;
+			if (isStandardSchema(value)) {
+				expectTypeOf(value).toEqualTypeOf<StandardSchemaV1>();
+			}
 		});
 	});
 });


### PR DESCRIPTION
## Problem

`isStandardSchema` (the guard that detects Zod/Valibot/ArkType schemas) and the `StandardSchemaV1` type are internal. Tools built on type-flag — e.g. cleye, which inspects flag definitions for help and defaults — have to vendor their own copy of the check, which can silently drift from type-flag's behavior.

## Changes

- Export `isStandardSchema` (a `value is StandardSchemaV1` type guard) and the `StandardSchemaV1` type from the package entry.
- Consolidate all Standard Schema logic into `src/standard-schema.ts`: the vendored spec type now sits alongside the `isStandardSchema` guard and the internal `schemaToParser` adapter, both moved out of `utils.ts` (which now imports them). The resulting import cycle with `types.ts` is type-only, so it's erased at build — no runtime cycle.
- Add `isStandardSchema` tests: detection across Zod/Valibot/ArkType vs parser functions/plain objects/primitives, plus guard narrowing and a check that `StandardSchemaV1.InferOutput` is usable through the export.

No change to parsing behavior. Verified green: type-check, tests (current Node + 18.20.3 via tsx), build, lint.
