### PR TITLE
feat: expose internal helpers via type-flag/internal

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,14 +25,25 @@
 	],
 	"type": "module",
 	"exports": {
-		"types": "./dist/index.d.ts",
-		"default": "./dist/index.mjs"
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.mjs"
+		},
+		"./internal": {
+			"types": "./dist/internal.d.ts",
+			"default": "./dist/internal.mjs"
+		}
 	},
 	"imports": {
 		"#type-flag": {
 			"types": "./src/index.ts",
 			"development": "./src/index.ts",
 			"default": "./dist/index.mjs"
+		},
+		"#type-flag/internal": {
+			"types": "./src/internal.ts",
+			"development": "./src/internal.ts",
+			"default": "./dist/internal.mjs"
 		}
 	},
 	"packageManager": "pnpm@10.13.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,5 @@
 export { typeFlag } from './type-flag.ts';
 export { getFlag } from './get-flag.ts';
-export { flagNameToKebab } from './utils.ts';
-export { createPositionalArguments } from './positional-arguments.ts';
-export { isStandardSchema, type StandardSchemaV1 } from './standard-schema.ts';
 export type {
 	TypeFlag,
 	TypeFlagOptions,

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1,0 +1,10 @@
+/**
+ * Lower-level helpers for tooling built on top of type-flag (e.g. cleye).
+ *
+ * These are exposed via the `type-flag/internal` subpath to keep the main entry
+ * focused on the common API. They are not part of the main public surface;
+ * prefer `type-flag` unless you are building tooling on type-flag.
+ */
+export { flagNameToKebab } from './utils.ts';
+export { createPositionalArguments } from './positional-arguments.ts';
+export { isStandardSchema, type StandardSchemaV1 } from './standard-schema.ts';

--- a/src/positional-arguments.ts
+++ b/src/positional-arguments.ts
@@ -9,6 +9,10 @@ export const createPositionalArgumentsFromParts = (
 	{ [DOUBLE_DASH]: doubleDashArguments },
 );
 
+/**
+ * Build a {@link PositionalArguments} array from raw argv, splitting on the
+ * `--` delimiter so tokens after `--` are also exposed on the `'--'` property.
+ */
 export const createPositionalArguments = (
 	argv: readonly string[],
 ): PositionalArguments => {

--- a/tests/specs/flag-name-to-kebab/index.ts
+++ b/tests/specs/flag-name-to-kebab/index.ts
@@ -1,5 +1,6 @@
 import { test, expect } from 'manten';
-import { flagNameToKebab, typeFlag } from '#type-flag';
+import { typeFlag } from '#type-flag';
+import { flagNameToKebab } from '#type-flag/internal';
 
 test('standard camelCase', () => {
 	expect(flagNameToKebab('fooBar')).toBe('foo-bar');

--- a/tests/specs/standard-schema.ts
+++ b/tests/specs/standard-schema.ts
@@ -6,9 +6,8 @@ import { type } from 'arktype';
 import {
 	typeFlag,
 	getFlag,
-	isStandardSchema,
-	type StandardSchemaV1,
 } from '#type-flag';
+import { isStandardSchema, type StandardSchemaV1 } from '#type-flag/internal';
 
 describe('standard-schema', () => {
 	describe('Zod', () => {

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -1,8 +1,6 @@
 import { describe, test, expect } from 'manten';
-import {
-	typeFlag,
-	createPositionalArguments,
-} from '#type-flag';
+import { typeFlag } from '#type-flag';
+import { createPositionalArguments } from '#type-flag/internal';
 
 describe('Parsing', () => {
 	describe('edge-cases', () => {

--- a/tests/specs/type-flag/types.ts
+++ b/tests/specs/type-flag/types.ts
@@ -2,13 +2,13 @@ import { describe, test } from 'manten';
 import { expectTypeOf } from 'expect-type';
 import {
 	typeFlag,
-	createPositionalArguments,
 	type Flags,
 	type TypeFlag,
 	type TypeFlagOptions,
 	type IgnoreFunction,
 	type PositionalArguments,
 } from '#type-flag';
+import { createPositionalArguments } from '#type-flag/internal';
 
 // Test Helpers
 const toDate = (s: string) => new Date(s);


### PR DESCRIPTION
## Problem

The main entry accumulated low-level helpers only relevant to tooling built on type-flag (e.g. cleye) — `flagNameToKebab`, `isStandardSchema`, `createPositionalArguments`, `StandardSchemaV1` — cluttering the API a general user sees.

## Changes

Move them to a new `type-flag/internal` subpath so the main entry stays focused on the common API:

- `type-flag` — `typeFlag`, `getFlag`, and the core types
- `type-flag/internal` — `flagNameToKebab`, `createPositionalArguments`, `isStandardSchema`, `StandardSchemaV1`

`type-flag/internal` is the surface for tooling/2nd-party consumers; it is not part of the stable public API and is documented via TSDoc.

BREAKING CHANGE: `flagNameToKebab`, `isStandardSchema`, `createPositionalArguments`, and `StandardSchemaV1` are no longer exported from the main entry; import them from `type-flag/internal`.
