### PR TITLE
feat: support negative numbers as flag values

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ A few trade-offs are intentional:
 
 - It does not parse POSIX-style short string values like `-ovalue`.
 - It treats missing string values as `""`; strict parsers like `parseArgs()` and `arg` throw.
-- For negative numeric values, use inline values like `--count=-1`; space-separated `--count -1` is parsed as a flag-like token today.
+- Negative numbers are accepted as flag values (`--count -1`); but a number that is itself a defined flag (e.g. a `-1` alias) is treated as that flag, so use `--count=-1` for it. A bare negative (not after a value-taking flag) and `-Infinity` also need the `=` form.
 
 ## Agent Skills
 

--- a/skills/type-flag/SKILL.md
+++ b/skills/type-flag/SKILL.md
@@ -165,7 +165,7 @@ Same argv-mutation behavior as `typeFlag`.
 
 | Gotcha | Detail |
 |--------|--------|
-| Negative numbers look like flag groups | `--num -123` is parsed as `-1 -2 -3` (char group). Use `--num=-123` or `--num=-Inf`. |
+| Negative numbers as values | `--num -5` is taken as `--num`'s value. Value-slot only: a standalone `-5`, or a `-5` that resolves to defined flags, still parses as a flag. `-Infinity`/`-NaN` (no leading digit) need `--num=-Infinity`. |
 | `argv` is mutated | Parsed tokens are spliced out. Don't share argv with other parsers after. |
 | Frozen argv throws | `Object.freeze(argv)` breaks the splice. Pass a mutable copy. |
 | `unknownFlags` keys are raw | NOT camelCased — so you can distinguish `--some-flag` from `--someFlag`. |

--- a/src/argv-iterator.ts
+++ b/src/argv-iterator.ts
@@ -91,7 +91,7 @@ export const argvIterator = (
 	{
 		onFlag,
 		onArgument,
-		isValueToken,
+		isFlagValue,
 	}: {
 		onFlag?: onFlag;
 		onArgument?: onArgument;
@@ -100,7 +100,7 @@ export const argvIterator = (
 		 * Returns whether a flag-shaped token should instead be consumed as the
 		 * value of a value-expecting flag (e.g. a negative number like `-5`).
 		 */
-		isValueToken?: (argvElement: string) => boolean;
+		isFlagValue?: (argvElement: string) => boolean;
 	},
 ) => {
 	let onValueCallback: void | onValueCallbackType;
@@ -129,10 +129,10 @@ export const argvIterator = (
 		}
 
 		// A value-expecting flag consumes a negative-number token as its value,
-		// unless the token resolves to defined flags (decided by isValueToken).
+		// unless the token resolves to defined flags (decided by isFlagValue).
 		if (
 			hasPendingValue()
-			&& isValueToken?.(argvElement)
+			&& isFlagValue?.(argvElement)
 		) {
 			triggerValueCallback(argvElement, [i]);
 			continue;

--- a/src/argv-iterator.ts
+++ b/src/argv-iterator.ts
@@ -1,5 +1,3 @@
-import { hasOwn } from './utils.ts';
-
 export const DOUBLE_DASH = '--';
 
 export const ALIAS_INDEX_LENGTH = 3;
@@ -30,25 +28,32 @@ const isFlagPattern = /^-{1,2}\w/;
 const negativeNumberPattern = /^-(?:\d+(?:\.\d*)?|\.\d+)(?:e[-+]?\d+)?$/i;
 
 /**
+ * A membership-checkable collection of defined flag/alias names. Both the
+ * `typeFlag` registry (a `Map`) and `getFlag`'s searched names (a `Set`)
+ * satisfy this, so neither call site needs a wrapper or conversion.
+ */
+type KnownFlags = {
+	has: (flagName: string) => boolean;
+};
+
+/**
  * Whether a flag-shaped token should be consumed as the value of a
  * value-expecting flag: it must look like a single-dash negative number
  * (e.g. `-5`, `-5.5`, `-5e3`) and NOT fully resolve to defined flags.
  *
- * `knownFlags` is the set of defined flag/alias names (the flag registry, or
- * getFlag's searched names). If every character after the dash is a known
- * flag, the token wins as a flag/alias group instead (e.g. `-512` when 5, 1,
- * and 2 are all defined).
+ * If every character after the dash is a known flag, the token wins as a
+ * flag/alias group instead (e.g. `-512` when 5, 1, and 2 are all defined).
  */
-export const isNegativeNumberValue = (
+const isNegativeNumberValue = (
 	argvElement: string,
-	knownFlags: Record<string, unknown>,
+	knownFlags: KnownFlags,
 ) => {
 	if (!negativeNumberPattern.test(argvElement)) {
 		return false;
 	}
 
 	for (let i = 1; i < argvElement.length; i += 1) {
-		if (!hasOwn(knownFlags, argvElement[i])) {
+		if (!knownFlags.has(argvElement[i])) {
 			return true;
 		}
 	}
@@ -94,16 +99,17 @@ export const argvIterator = (
 	{
 		onFlag,
 		onArgument,
-		isFlagValue,
+		knownFlags,
 	}: {
 		onFlag?: onFlag;
 		onArgument?: onArgument;
 
 		/**
-		 * Returns whether a flag-shaped token should instead be consumed as the
-		 * value of a value-expecting flag (e.g. a negative number like `-5`).
+		 * Defined flag/alias names. Used to decide whether a negative-number
+		 * token (e.g. `-5`) should be consumed as a flag's value rather than
+		 * parsed as a flag. A `Map` registry and a `Set` of names both satisfy it.
 		 */
-		isFlagValue?: (argvElement: string) => boolean;
+		knownFlags?: KnownFlags;
 	},
 ) => {
 	let onValueCallback!: void | onValueCallbackType;
@@ -131,10 +137,11 @@ export const argvIterator = (
 		}
 
 		// A value-expecting flag consumes a negative-number token as its value,
-		// unless the token resolves to defined flags (decided by isFlagValue).
+		// unless the token resolves to defined flags.
 		if (
 			onValueCallback
-			&& isFlagValue?.(argvElement)
+			&& knownFlags
+			&& isNegativeNumberValue(argvElement, knownFlags)
 		) {
 			triggerValueCallback(argvElement, [i]);
 			continue;

--- a/src/argv-iterator.ts
+++ b/src/argv-iterator.ts
@@ -1,3 +1,5 @@
+import { hasOwn } from './utils.ts';
+
 export const DOUBLE_DASH = '--';
 
 export const ALIAS_INDEX_LENGTH = 3;
@@ -32,20 +34,21 @@ const negativeNumberPattern = /^-(?:\d+(?:\.\d*)?|\.\d+)(?:e[-+]?\d+)?$/i;
  * value-expecting flag: it must look like a single-dash negative number
  * (e.g. `-5`, `-5.5`, `-5e3`) and NOT fully resolve to defined flags.
  *
- * `isKnownFlag` reports whether a single character is a defined flag/alias.
- * If every character after the dash is known, the token wins as a flag/alias
- * group instead (e.g. `-512` when 5, 1, and 2 are all defined).
+ * `knownFlags` is the set of defined flag/alias names (the flag registry, or
+ * getFlag's searched names). If every character after the dash is a known
+ * flag, the token wins as a flag/alias group instead (e.g. `-512` when 5, 1,
+ * and 2 are all defined).
  */
 export const isNegativeNumberValue = (
 	argvElement: string,
-	isKnownFlag: (flagName: string) => boolean,
+	knownFlags: Record<string, unknown>,
 ) => {
 	if (!negativeNumberPattern.test(argvElement)) {
 		return false;
 	}
 
 	for (let i = 1; i < argvElement.length; i += 1) {
-		if (!isKnownFlag(argvElement[i])) {
+		if (!hasOwn(knownFlags, argvElement[i])) {
 			return true;
 		}
 	}

--- a/src/argv-iterator.ts
+++ b/src/argv-iterator.ts
@@ -52,12 +52,15 @@ const isNegativeNumberValue = (
 		return false;
 	}
 
+	// A flag/alias group requires EVERY character to be a defined flag, so the
+	// first non-flag character means the token is a value (e.g. the `0` in `-50`).
 	for (let i = 1; i < argvElement.length; i += 1) {
 		if (!knownFlags.has(argvElement[i])) {
 			return true;
 		}
 	}
 
+	// Every character is a defined flag (e.g. `-512` when 5, 1, 2 are defined).
 	return false;
 };
 

--- a/src/argv-iterator.ts
+++ b/src/argv-iterator.ts
@@ -25,6 +25,34 @@ type onArgument = (
 
 const isFlagPattern = /^-{1,2}\w/;
 
+const negativeNumberPattern = /^-(?:\d+(?:\.\d*)?|\.\d+)(?:e[-+]?\d+)?$/i;
+
+/**
+ * Whether a flag-shaped token should be consumed as the value of a
+ * value-expecting flag: it must look like a single-dash negative number
+ * (e.g. `-5`, `-5.5`, `-5e3`) and NOT fully resolve to defined flags.
+ *
+ * `isKnownFlag` reports whether a single character is a defined flag/alias.
+ * If every character after the dash is known, the token wins as a flag/alias
+ * group instead (e.g. `-512` when 5, 1, and 2 are all defined).
+ */
+export const isNegativeNumberValue = (
+	argvElement: string,
+	isKnownFlag: (flagName: string) => boolean,
+) => {
+	if (!negativeNumberPattern.test(argvElement)) {
+		return false;
+	}
+
+	for (let i = 1; i < argvElement.length; i += 1) {
+		if (!isKnownFlag(argvElement[i])) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
 export const parseFlagArgv = (
 	flagArgv: string,
 ): [
@@ -63,9 +91,16 @@ export const argvIterator = (
 	{
 		onFlag,
 		onArgument,
+		isValueToken,
 	}: {
 		onFlag?: onFlag;
 		onArgument?: onArgument;
+
+		/**
+		 * Returns whether a flag-shaped token should instead be consumed as the
+		 * value of a value-expecting flag (e.g. a negative number like `-5`).
+		 */
+		isValueToken?: (argvElement: string) => boolean;
 	},
 ) => {
 	let onValueCallback: void | onValueCallbackType;
@@ -80,6 +115,7 @@ export const argvIterator = (
 		onValueCallback(value, index);
 		onValueCallback = undefined;
 	};
+	const hasPendingValue = () => typeof onValueCallback === 'function';
 
 	for (let i = 0; i < argv.length; i += 1) {
 		const argvElement = argv[i];
@@ -90,6 +126,16 @@ export const argvIterator = (
 			const remaining = argv.slice(i + 1);
 			onArgument?.(remaining, [i], true);
 			break;
+		}
+
+		// A value-expecting flag consumes a negative-number token as its value,
+		// unless the token resolves to defined flags (decided by isValueToken).
+		if (
+			hasPendingValue()
+			&& isValueToken?.(argvElement)
+		) {
+			triggerValueCallback(argvElement, [i]);
+			continue;
 		}
 
 		const parsedFlag = parseFlagArgv(argvElement);

--- a/src/argv-iterator.ts
+++ b/src/argv-iterator.ts
@@ -103,7 +103,7 @@ export const argvIterator = (
 		isFlagValue?: (argvElement: string) => boolean;
 	},
 ) => {
-	let onValueCallback: void | onValueCallbackType;
+	let onValueCallback!: void | onValueCallbackType;
 	const triggerValueCallback = (
 		value?: string,
 		index?: Index,
@@ -115,7 +115,6 @@ export const argvIterator = (
 		onValueCallback(value, index);
 		onValueCallback = undefined;
 	};
-	const hasPendingValue = () => typeof onValueCallback === 'function';
 
 	for (let i = 0; i < argv.length; i += 1) {
 		const argvElement = argv[i];
@@ -131,7 +130,7 @@ export const argvIterator = (
 		// A value-expecting flag consumes a negative-number token as its value,
 		// unless the token resolves to defined flags (decided by isFlagValue).
 		if (
-			hasPendingValue()
+			onValueCallback
 			&& isFlagValue?.(argvElement)
 		) {
 			triggerValueCallback(argvElement, [i]);

--- a/src/get-flag.ts
+++ b/src/get-flag.ts
@@ -6,6 +6,7 @@ import {
 	parseFlagType,
 	normalizeBoolean,
 	applyParser,
+	hasOwn,
 } from './utils.ts';
 import {
 	argvIterator,
@@ -20,21 +21,22 @@ export const getFlag = <Type extends FlagType>(
 	flagType: Type,
 	argv = process.argv.slice(2),
 ) => {
-	const flags = new Set(
-		flagNames.split(',').map(name => parseFlagArgv(name)?.[0]),
-	);
+	const flags: Record<string, true> = {};
+	for (const flagName of flagNames.split(',')) {
+		const parsedName = parseFlagArgv(flagName)?.[0];
+		if (parsedName) {
+			flags[parsedName] = true;
+		}
+	}
 	const [parser, gatherAll] = parseFlagType(flagType);
 	const results: unknown[] = [];
 	const removeArgvs: Index[] = [];
 
 	argvIterator(argv, {
-		isFlagValue: argvElement => isNegativeNumberValue(
-			argvElement,
-			flagName => flags.has(flagName),
-		),
+		isFlagValue: argvElement => isNegativeNumberValue(argvElement, flags),
 		onFlag: (name, explicitValue, flagIndex) => {
 			if (
-				!flags.has(name)
+				!hasOwn(flags, name)
 				|| (!gatherAll && results.length > 0)
 			) {
 				return;

--- a/src/get-flag.ts
+++ b/src/get-flag.ts
@@ -21,7 +21,8 @@ export const getFlag = <Type extends FlagType>(
 	flagType: Type,
 	argv = process.argv.slice(2),
 ) => {
-	const flags: Record<string, true> = {};
+	// Null-prototype map so flag names like `__proto__` are stored as own keys.
+	const flags: Record<string, true> = Object.create(null);
 	for (const flagName of flagNames.split(',')) {
 		const parsedName = parseFlagArgv(flagName)?.[0];
 		if (parsedName) {

--- a/src/get-flag.ts
+++ b/src/get-flag.ts
@@ -9,6 +9,7 @@ import {
 } from './utils.ts';
 import {
 	argvIterator,
+	isNegativeNumberValue,
 	parseFlagArgv,
 	spliceFromArgv,
 	type Index,
@@ -27,6 +28,10 @@ export const getFlag = <Type extends FlagType>(
 	const removeArgvs: Index[] = [];
 
 	argvIterator(argv, {
+		isValueToken: argvElement => isNegativeNumberValue(
+			argvElement,
+			flagName => flags.has(flagName),
+		),
 		onFlag: (name, explicitValue, flagIndex) => {
 			if (
 				!flags.has(name)

--- a/src/get-flag.ts
+++ b/src/get-flag.ts
@@ -28,7 +28,7 @@ export const getFlag = <Type extends FlagType>(
 	const removeArgvs: Index[] = [];
 
 	argvIterator(argv, {
-		isValueToken: argvElement => isNegativeNumberValue(
+		isFlagValue: argvElement => isNegativeNumberValue(
 			argvElement,
 			flagName => flags.has(flagName),
 		),

--- a/src/get-flag.ts
+++ b/src/get-flag.ts
@@ -6,11 +6,9 @@ import {
 	parseFlagType,
 	normalizeBoolean,
 	applyParser,
-	hasOwn,
 } from './utils.ts';
 import {
 	argvIterator,
-	isNegativeNumberValue,
 	parseFlagArgv,
 	spliceFromArgv,
 	type Index,
@@ -21,23 +19,18 @@ export const getFlag = <Type extends FlagType>(
 	flagType: Type,
 	argv = process.argv.slice(2),
 ) => {
-	// Null-prototype map so flag names like `__proto__` are stored as own keys.
-	const flags: Record<string, true> = Object.create(null);
-	for (const flagName of flagNames.split(',')) {
-		const parsedName = parseFlagArgv(flagName)?.[0];
-		if (parsedName) {
-			flags[parsedName] = true;
-		}
-	}
+	const flags = new Set(
+		flagNames.split(',').map(name => parseFlagArgv(name)?.[0]),
+	);
 	const [parser, gatherAll] = parseFlagType(flagType);
 	const results: unknown[] = [];
 	const removeArgvs: Index[] = [];
 
 	argvIterator(argv, {
-		isFlagValue: argvElement => isNegativeNumberValue(argvElement, flags),
+		knownFlags: flags,
 		onFlag: (name, explicitValue, flagIndex) => {
 			if (
-				!hasOwn(flags, name)
+				!flags.has(name)
 				|| (!gatherAll && results.length > 0)
 			) {
 				return;

--- a/src/type-flag.ts
+++ b/src/type-flag.ts
@@ -18,7 +18,6 @@ import { createPositionalArgumentsFromParts } from './positional-arguments.ts';
 import {
 	ALIAS_INDEX_LENGTH,
 	argvIterator,
-	isNegativeNumberValue,
 	spliceFromArgv,
 	type Index,
 } from './argv-iterator.ts';
@@ -55,33 +54,30 @@ export const typeFlag = <Schemas extends Flags>(
 	let doubleDashArguments: string[] = [];
 
 	argvIterator(argv, {
-		isFlagValue: argvElement => isNegativeNumberValue(argvElement, flagRegistry),
+		knownFlags: flagRegistry,
 		onFlag(name, explicitValue, flagIndex) {
 			const isAlias = flagIndex.length === ALIAS_INDEX_LENGTH;
 			// Long-form requires length > 1; single-char names are exclusive to short-form (-h vs --help)
 			const isValid = isAlias || name.length > 1;
-			const isKnownFlag = isValid && hasOwn(flagRegistry, name);
+			const flagData = isValid ? flagRegistry.get(name) : undefined;
 
-			let negatedBase: string | undefined;
+			let negatedBaseValues: unknown[] | undefined;
 			if (
-				!isKnownFlag
+				!flagData
 				&& booleanNegation
 				&& !isAlias
 				&& name.length > 3
 				&& name.startsWith('no-')
 			) {
-				const baseName = name.slice(3);
-				if (
-					hasOwn(flagRegistry, baseName)
-					&& flagRegistry[baseName][1] === Boolean
-				) {
-					negatedBase = baseName;
+				const baseData = flagRegistry.get(name.slice(3));
+				if (baseData && baseData[1] === Boolean) {
+					negatedBaseValues = baseData[0];
 				}
 			}
 
 			if (
 				ignore?.(
-					isKnownFlag || negatedBase ? KNOWN_FLAG : UNKNOWN_FLAG,
+					flagData || negatedBaseValues ? KNOWN_FLAG : UNKNOWN_FLAG,
 					name,
 					explicitValue,
 				)
@@ -89,8 +85,8 @@ export const typeFlag = <Schemas extends Flags>(
 				return;
 			}
 
-			if (isKnownFlag) {
-				const [values, parser] = flagRegistry[name];
+			if (flagData) {
+				const [values, parser] = flagData;
 				const flagValue = normalizeBoolean(parser, explicitValue);
 				const getFollowingValue = (
 					value?: string | boolean,
@@ -114,8 +110,8 @@ export const typeFlag = <Schemas extends Flags>(
 				);
 			}
 
-			if (negatedBase) {
-				flagRegistry[negatedBase][0].push(false);
+			if (negatedBaseValues) {
+				negatedBaseValues.push(false);
 				removeArgvs.push(flagIndex);
 				return;
 			}

--- a/src/type-flag.ts
+++ b/src/type-flag.ts
@@ -18,6 +18,7 @@ import { createPositionalArgumentsFromParts } from './positional-arguments.ts';
 import {
 	ALIAS_INDEX_LENGTH,
 	argvIterator,
+	isNegativeNumberValue,
 	spliceFromArgv,
 	type Index,
 } from './argv-iterator.ts';
@@ -54,6 +55,10 @@ export const typeFlag = <Schemas extends Flags>(
 	let doubleDashArguments: string[] = [];
 
 	argvIterator(argv, {
+		isValueToken: argvElement => isNegativeNumberValue(
+			argvElement,
+			flagName => hasOwn(flagRegistry, flagName),
+		),
 		onFlag(name, explicitValue, flagIndex) {
 			const isAlias = flagIndex.length === ALIAS_INDEX_LENGTH;
 			// Long-form requires length > 1; single-char names are exclusive to short-form (-h vs --help)

--- a/src/type-flag.ts
+++ b/src/type-flag.ts
@@ -55,10 +55,7 @@ export const typeFlag = <Schemas extends Flags>(
 	let doubleDashArguments: string[] = [];
 
 	argvIterator(argv, {
-		isFlagValue: argvElement => isNegativeNumberValue(
-			argvElement,
-			flagName => hasOwn(flagRegistry, flagName),
-		),
+		isFlagValue: argvElement => isNegativeNumberValue(argvElement, flagRegistry),
 		onFlag(name, explicitValue, flagIndex) {
 			const isAlias = flagIndex.length === ALIAS_INDEX_LENGTH;
 			// Long-form requires length > 1; single-char names are exclusive to short-form (-h vs --help)

--- a/src/type-flag.ts
+++ b/src/type-flag.ts
@@ -55,7 +55,7 @@ export const typeFlag = <Schemas extends Flags>(
 	let doubleDashArguments: string[] = [];
 
 	argvIterator(argv, {
-		isValueToken: argvElement => isNegativeNumberValue(
+		isFlagValue: argvElement => isNegativeNumberValue(
 			argvElement,
 			flagName => hasOwn(flagRegistry, flagName),
 		),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,26 +112,24 @@ type FlagParsingData = [
 	schema: FlagTypeOrSchema,
 ];
 
-type FlagRegistry = {
-	[flagName: string]: FlagParsingData;
-};
+type FlagRegistry = Map<string, FlagParsingData>;
 
 const setFlag = (
 	registry: FlagRegistry,
 	flagName: string,
 	data: FlagParsingData,
 ) => {
-	if (hasOwn(registry, flagName)) {
+	if (registry.has(flagName)) {
 		throw new Error(`Duplicate flags named "${flagName}"`);
 	}
 
-	registry[flagName] = data;
+	registry.set(flagName, data);
 };
 
 export const createRegistry = (
 	schemas: Flags,
 ) => {
-	const registry: FlagRegistry = {};
+	const registry: FlagRegistry = new Map();
 
 	for (const flagName in schemas) {
 		if (!hasOwn(schemas, flagName)) {
@@ -187,7 +185,12 @@ export const finalizeFlags = (
 			continue;
 		}
 
-		const [values, , isArray, schema] = registry[flagName];
+		const flagData = registry.get(flagName);
+		if (!flagData) {
+			continue;
+		}
+
+		const [values, , isArray, schema] = flagData;
 		if (
 			values.length === 0
 			// A raw schema (e.g. Zod, ArkType) can have its own `.default`; only a

--- a/tests/specs/get-flag/parsing.ts
+++ b/tests/specs/get-flag/parsing.ts
@@ -76,6 +76,14 @@ describe('Parsing', () => {
 			expect<boolean[]>(flagValue).toStrictEqual([true, true]);
 			expect(argv).toStrictEqual(['--unknown']);
 		});
+
+		test('flag named __proto__', () => {
+			const argv = ['--__proto__'];
+			const flagValue = getFlag('--__proto__', Boolean, argv);
+
+			expect<boolean | undefined>(flagValue).toBe(true);
+			expect(argv).toStrictEqual([]);
+		});
 	});
 
 	test('ignores argv', () => {

--- a/tests/specs/get-flag/parsing.ts
+++ b/tests/specs/get-flag/parsing.ts
@@ -117,4 +117,30 @@ describe('Parsing', () => {
 		expect<string | undefined>(flagValue).toBe('value');
 		expect(argv).toStrictEqual(['--', '--flag', 'after']);
 	});
+
+	describe('negative number values', () => {
+		test('named flag consumes negative', () => {
+			const argv = ['--retry', '-5'];
+			const flagValue = getFlag('--retry', Number, argv);
+
+			expect<number | undefined>(flagValue).toBe(-5);
+			expect(argv).toStrictEqual([]);
+		});
+
+		test('alias consumes negative', () => {
+			const argv = ['-n', '-5'];
+			const flagValue = getFlag('-n', Number, argv);
+
+			expect<number | undefined>(flagValue).toBe(-5);
+			expect(argv).toStrictEqual([]);
+		});
+
+		test('negative not for the searched flag is left untouched', () => {
+			const argv = ['--foo', '-5', '--retry', '3'];
+			const flagValue = getFlag('--retry', Number, argv);
+
+			expect<number | undefined>(flagValue).toBe(3);
+			expect(argv).toStrictEqual(['--foo', '-5']);
+		});
+	});
 });

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -168,7 +168,12 @@ describe('Parsing', () => {
 		});
 
 		test('consumes negative via alias', () => {
-			const parsed = typeFlag({ retry: { type: Number, alias: 'r' } }, ['-r', '-5']);
+			const parsed = typeFlag({
+				retry: {
+					type: Number,
+					alias: 'r',
+				},
+			}, ['-r', '-5']);
 
 			expect<{ retry?: number }>(parsed.flags).toStrictEqual({ retry: -5 });
 		});
@@ -195,64 +200,126 @@ describe('Parsing', () => {
 			test('-5 resolves to the defined flag, not a value', () => {
 				const parsed = typeFlag({
 					retry: Number,
-					fast: { type: Boolean, alias: '5' },
-					name: { type: String, alias: 'n' },
+					fast: {
+						type: Boolean,
+						alias: '5',
+					},
+					name: {
+						type: String,
+						alias: 'n',
+					},
 				}, ['--retry', '-5']);
 
-				expect(parsed.flags).toStrictEqual({ retry: Number.NaN, fast: true, name: undefined });
+				expect(parsed.flags).toStrictEqual({
+					retry: Number.NaN,
+					fast: true,
+					name: undefined,
+				});
 				expect(parsed.unknownFlags).toStrictEqual({});
 			});
 
 			test('-5 then -n value', () => {
 				const parsed = typeFlag({
 					retry: Number,
-					fast: { type: Boolean, alias: '5' },
-					name: { type: String, alias: 'n' },
+					fast: {
+						type: Boolean,
+						alias: '5',
+					},
+					name: {
+						type: String,
+						alias: 'n',
+					},
 				}, ['--retry', '-5', '-n', 'Hiroki']);
 
-				expect(parsed.flags).toStrictEqual({ retry: Number.NaN, fast: true, name: 'Hiroki' });
+				expect(parsed.flags).toStrictEqual({
+					retry: Number.NaN,
+					fast: true,
+					name: 'Hiroki',
+				});
 			});
 
 			test('alias group -5n', () => {
 				const parsed = typeFlag({
 					retry: Number,
-					fast: { type: Boolean, alias: '5' },
-					name: { type: String, alias: 'n' },
+					fast: {
+						type: Boolean,
+						alias: '5',
+					},
+					name: {
+						type: String,
+						alias: 'n',
+					},
 				}, ['--retry', '-5n', 'Hiroki']);
 
-				expect(parsed.flags).toStrictEqual({ retry: Number.NaN, fast: true, name: 'Hiroki' });
+				expect(parsed.flags).toStrictEqual({
+					retry: Number.NaN,
+					fast: true,
+					name: 'Hiroki',
+				});
 			});
 
 			test('partial match -50 is a number', () => {
 				const parsed = typeFlag({
 					retry: Number,
-					fast: { type: Boolean, alias: '5' },
-					name: { type: String, alias: 'n' },
+					fast: {
+						type: Boolean,
+						alias: '5',
+					},
+					name: {
+						type: String,
+						alias: 'n',
+					},
 				}, ['--retry', '-50']);
 
-				expect(parsed.flags).toStrictEqual({ retry: -50, fast: undefined, name: undefined });
+				expect(parsed.flags).toStrictEqual({
+					retry: -50,
+					fast: undefined,
+					name: undefined,
+				});
 			});
 
 			test('decimal -5.5 is a number even when 5 is a flag', () => {
 				const parsed = typeFlag({
 					retry: Number,
-					fast: { type: Boolean, alias: '5' },
-					name: { type: String, alias: 'n' },
+					fast: {
+						type: Boolean,
+						alias: '5',
+					},
+					name: {
+						type: String,
+						alias: 'n',
+					},
 				}, ['--retry', '-5.5']);
 
-				expect(parsed.flags).toStrictEqual({ retry: -5.5, fast: undefined, name: undefined });
+				expect(parsed.flags).toStrictEqual({
+					retry: -5.5,
+					fast: undefined,
+					name: undefined,
+				});
 			});
 
 			test('all-digit alias group -512', () => {
 				const parsed = typeFlag({
 					retry: Number,
-					alpha: { type: Boolean, alias: '5' },
-					beta: { type: Boolean, alias: '1' },
-					gamma: { type: Boolean, alias: '2' },
+					alpha: {
+						type: Boolean,
+						alias: '5',
+					},
+					beta: {
+						type: Boolean,
+						alias: '1',
+					},
+					gamma: {
+						type: Boolean,
+						alias: '2',
+					},
 				}, ['--retry', '-512']);
 
 				expect(parsed.flags).toStrictEqual({
-					retry: Number.NaN, alpha: true, beta: true, gamma: true,
+					retry: Number.NaN,
+					alpha: true,
+					beta: true,
+					gamma: true,
 				});
 			});
 		});
@@ -261,37 +328,61 @@ describe('Parsing', () => {
 			test('unregistered negative is a value', () => {
 				const parsed = typeFlag({
 					retry: Number,
-					one: { type: Boolean, alias: '1' },
+					one: {
+						type: Boolean,
+						alias: '1',
+					},
 				}, ['--retry', '-5']);
 
-				expect(parsed.flags).toStrictEqual({ retry: -5, one: undefined });
+				expect(parsed.flags).toStrictEqual({
+					retry: -5,
+					one: undefined,
+				});
 			});
 
 			test('registered -1 standalone is the flag', () => {
 				const parsed = typeFlag({
 					retry: Number,
-					one: { type: Boolean, alias: '1' },
+					one: {
+						type: Boolean,
+						alias: '1',
+					},
 				}, ['-1']);
 
-				expect(parsed.flags).toStrictEqual({ retry: undefined, one: true });
+				expect(parsed.flags).toStrictEqual({
+					retry: undefined,
+					one: true,
+				});
 			});
 
 			test('value and flag in one command', () => {
 				const parsed = typeFlag({
 					retry: Number,
-					one: { type: Boolean, alias: '1' },
+					one: {
+						type: Boolean,
+						alias: '1',
+					},
 				}, ['-1', '--retry', '-5']);
 
-				expect(parsed.flags).toStrictEqual({ retry: -5, one: true });
+				expect(parsed.flags).toStrictEqual({
+					retry: -5,
+					one: true,
+				});
 			});
 
 			test('registered -1 wins after a value flag', () => {
 				const parsed = typeFlag({
 					retry: Number,
-					one: { type: Boolean, alias: '1' },
+					one: {
+						type: Boolean,
+						alias: '1',
+					},
 				}, ['--retry', '-1']);
 
-				expect(parsed.flags).toStrictEqual({ retry: Number.NaN, one: true });
+				expect(parsed.flags).toStrictEqual({
+					retry: Number.NaN,
+					one: true,
+				});
 			});
 		});
 

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -65,25 +65,23 @@ describe('Parsing', () => {
 		});
 
 		test('Negative number with flag', () => {
+			const argv = ['--number', '-123'];
 			const parsed = typeFlag({
 				number: Number,
-			}, ['--number', '-123']);
+			}, argv);
 
-			// -123 is parsed as flag group -1 -2 -3, leaving number with no value
+			// -123 is consumed as the value for --number
 			expect<{ number?: number }>(parsed.flags).toStrictEqual({
-				number: Number.NaN,
+				number: -123,
 			});
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({
-				1: [true],
-				2: [true],
-				3: [true],
-			});
+			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({});
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(
 				Object.assign(
 					[],
 					{ '--': [] },
 				),
 			);
+			expect<string[]>(argv).toStrictEqual([]);
 		});
 
 		test('Negative number with equals', () => {
@@ -144,6 +142,190 @@ describe('Parsing', () => {
 				8: [true],
 				a: [true],
 			});
+		});
+	});
+
+	describe('negative number values', () => {
+		test('consumes negative integer', () => {
+			const argv = ['--retry', '-5'];
+			const parsed = typeFlag({ retry: Number }, argv);
+
+			expect<{ retry?: number }>(parsed.flags).toStrictEqual({ retry: -5 });
+			expect(parsed.unknownFlags).toStrictEqual({});
+			expect<string[]>(argv).toStrictEqual([]);
+		});
+
+		test('consumes negative decimal', () => {
+			const parsed = typeFlag({ retry: Number }, ['--retry', '-5.5']);
+
+			expect<{ retry?: number }>(parsed.flags).toStrictEqual({ retry: -5.5 });
+		});
+
+		test('consumes negative scientific notation', () => {
+			const parsed = typeFlag({ retry: Number }, ['--retry', '-5e3']);
+
+			expect<{ retry?: number }>(parsed.flags).toStrictEqual({ retry: -5000 });
+		});
+
+		test('consumes negative via alias', () => {
+			const parsed = typeFlag({ retry: { type: Number, alias: 'r' } }, ['-r', '-5']);
+
+			expect<{ retry?: number }>(parsed.flags).toStrictEqual({ retry: -5 });
+		});
+
+		test('explicit = value still works', () => {
+			const parsed = typeFlag({ retry: Number }, ['--retry=-5']);
+
+			expect<{ retry?: number }>(parsed.flags).toStrictEqual({ retry: -5 });
+		});
+
+		test('string flag consumes negative-number token', () => {
+			const parsed = typeFlag({ name: String }, ['--name', '-5']);
+
+			expect<{ name?: string }>(parsed.flags).toStrictEqual({ name: '-5' });
+		});
+
+		test('array of numbers consumes negatives', () => {
+			const parsed = typeFlag({ nums: [Number] }, ['--nums', '-1', '--nums', '-2']);
+
+			expect<{ nums: number[] }>(parsed.flags).toStrictEqual({ nums: [-1, -2] });
+		});
+
+		describe('defined flags take precedence', () => {
+			test('-5 resolves to the defined flag, not a value', () => {
+				const parsed = typeFlag({
+					retry: Number,
+					fast: { type: Boolean, alias: '5' },
+					name: { type: String, alias: 'n' },
+				}, ['--retry', '-5']);
+
+				expect(parsed.flags).toStrictEqual({ retry: Number.NaN, fast: true, name: undefined });
+				expect(parsed.unknownFlags).toStrictEqual({});
+			});
+
+			test('-5 then -n value', () => {
+				const parsed = typeFlag({
+					retry: Number,
+					fast: { type: Boolean, alias: '5' },
+					name: { type: String, alias: 'n' },
+				}, ['--retry', '-5', '-n', 'Hiroki']);
+
+				expect(parsed.flags).toStrictEqual({ retry: Number.NaN, fast: true, name: 'Hiroki' });
+			});
+
+			test('alias group -5n', () => {
+				const parsed = typeFlag({
+					retry: Number,
+					fast: { type: Boolean, alias: '5' },
+					name: { type: String, alias: 'n' },
+				}, ['--retry', '-5n', 'Hiroki']);
+
+				expect(parsed.flags).toStrictEqual({ retry: Number.NaN, fast: true, name: 'Hiroki' });
+			});
+
+			test('partial match -50 is a number', () => {
+				const parsed = typeFlag({
+					retry: Number,
+					fast: { type: Boolean, alias: '5' },
+					name: { type: String, alias: 'n' },
+				}, ['--retry', '-50']);
+
+				expect(parsed.flags).toStrictEqual({ retry: -50, fast: undefined, name: undefined });
+			});
+
+			test('decimal -5.5 is a number even when 5 is a flag', () => {
+				const parsed = typeFlag({
+					retry: Number,
+					fast: { type: Boolean, alias: '5' },
+					name: { type: String, alias: 'n' },
+				}, ['--retry', '-5.5']);
+
+				expect(parsed.flags).toStrictEqual({ retry: -5.5, fast: undefined, name: undefined });
+			});
+
+			test('all-digit alias group -512', () => {
+				const parsed = typeFlag({
+					retry: Number,
+					alpha: { type: Boolean, alias: '5' },
+					beta: { type: Boolean, alias: '1' },
+					gamma: { type: Boolean, alias: '2' },
+				}, ['--retry', '-512']);
+
+				expect(parsed.flags).toStrictEqual({
+					retry: Number.NaN, alpha: true, beta: true, gamma: true,
+				});
+			});
+		});
+
+		describe('coexists with numeric flags', () => {
+			test('unregistered negative is a value', () => {
+				const parsed = typeFlag({
+					retry: Number,
+					one: { type: Boolean, alias: '1' },
+				}, ['--retry', '-5']);
+
+				expect(parsed.flags).toStrictEqual({ retry: -5, one: undefined });
+			});
+
+			test('registered -1 standalone is the flag', () => {
+				const parsed = typeFlag({
+					retry: Number,
+					one: { type: Boolean, alias: '1' },
+				}, ['-1']);
+
+				expect(parsed.flags).toStrictEqual({ retry: undefined, one: true });
+			});
+
+			test('value and flag in one command', () => {
+				const parsed = typeFlag({
+					retry: Number,
+					one: { type: Boolean, alias: '1' },
+				}, ['-1', '--retry', '-5']);
+
+				expect(parsed.flags).toStrictEqual({ retry: -5, one: true });
+			});
+
+			test('registered -1 wins after a value flag', () => {
+				const parsed = typeFlag({
+					retry: Number,
+					one: { type: Boolean, alias: '1' },
+				}, ['--retry', '-1']);
+
+				expect(parsed.flags).toStrictEqual({ retry: Number.NaN, one: true });
+			});
+		});
+
+		describe('value-slot only', () => {
+			test('standalone negative is an unknown flag', () => {
+				const parsed = typeFlag({ retry: Number }, ['-7']);
+
+				expect(parsed.flags).toStrictEqual({ retry: undefined });
+				expect(parsed.unknownFlags).toStrictEqual({ 7: [true] });
+			});
+
+			test('boolean flag does not consume a following negative', () => {
+				const parsed = typeFlag({ verbose: Boolean }, ['--verbose', '-5']);
+
+				expect(parsed.flags).toStrictEqual({ verbose: true });
+				expect(parsed.unknownFlags).toStrictEqual({ 5: [true] });
+			});
+
+			test('array consumes one value; trailing negative is an unknown flag', () => {
+				const parsed = typeFlag({ nums: [Number] }, ['--nums', '-1', '-2']);
+
+				expect(parsed.flags).toStrictEqual({ nums: [-1] });
+				expect(parsed.unknownFlags).toStrictEqual({ 2: [true] });
+			});
+		});
+
+		test('end of flags wins over value consumption', () => {
+			const argv = ['--retry', '--', '-5'];
+			const parsed = typeFlag({ retry: Number }, argv);
+
+			expect<{ retry?: number }>(parsed.flags).toStrictEqual({ retry: Number.NaN });
+			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(
+				Object.assign(['-5'], { '--': ['-5'] }),
+			);
 		});
 	});
 
@@ -306,7 +488,7 @@ describe('Parsing', () => {
 		);
 
 		expect<number | undefined>(parsed.flags.infinity).toBe(Number.POSITIVE_INFINITY);
-		// Negative numbers must use = delimiter to avoid being parsed as flags
+		// -Infinity has no leading digit, so it still needs the = delimiter
 		expect<number | undefined>(parsed.flags.negInfinity).toBe(Number.NEGATIVE_INFINITY);
 		expect<number | undefined>(parsed.flags.scientific).toBe(1.5e10);
 		expect<number | undefined>(parsed.flags.negScientific).toBe(-2.3e-5);


### PR DESCRIPTION
## Problem

type-flag treated any `-`-prefixed token as a flag, so a negative number passed as a flag value was mis-parsed: `--retry -5` produced `retry: NaN` plus bogus unknown flags (`-1 -2 -3`). Negative values were only usable via the `=` form (`--retry=-5`).

## Changes

A value-expecting flag now consumes a following negative-number token (`-5`, `-5.5`, `-5e3`) as its value:

- **Value-slot only.** Only applies right after a value-taking flag. A standalone `-5` is unchanged (still parsed as a flag/alias).
- **Defined flags win.** If the token fully resolves to defined flags/aliases, those take precedence (e.g. `-5` when `5` is a registered alias, or `-512` when `5`, `1`, `2` are all defined). Use `--retry=-5` to force the value in that case.
- **Coexistence.** A `-1` flag and `--retry -5` can both exist; the number is consumed only when it isn't a defined flag.
- **Decimals/scientific stay numbers.** `-5.5` is a value even when `5` is a defined flag (`.` can't be an alias).
- Applies to both `typeFlag` and `getFlag` (shared tokenizer).
- `-Infinity` / `-NaN` (no leading digit) still require the `=` form.

Implemented as `isNegativeNumberValue` in `argv-iterator.ts`, threaded through both APIs via a new `isValueToken` predicate.

## Tests

Added an acceptance-criteria suite (`tests/specs/type-flag/parsing.ts`, `tests/specs/get-flag/parsing.ts`) covering value consumption, defined-flag precedence, coexistence, value-slot-only behavior, `--` precedence, and decimals. Built test-first (red), then implemented to green.

BREAKING CHANGE: a negative number following a value-taking flag (e.g. `--retry -5`) is now consumed as that flag's value instead of being parsed as a flag group.
