### PR TITLE
perf: skip kebab-case regex for lowercase flag names

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,9 +28,9 @@ const hasUpperCasePattern = /[A-Z]/;
  * ```
  */
 export const flagNameToKebab = (name: string): string => (
-	// Skip the look-around regex when there's no ASCII uppercase to split on.
-	// `toLowerCase()` is still needed for non-ASCII uppercase (e.g. `İ`) that
-	// `/[A-Z]/` doesn't detect.
+	// Perf: skip the costly look-around regex when there's no ASCII uppercase
+	// to split on (the common case). `toLowerCase()` is still needed for
+	// non-ASCII uppercase (e.g. `İ`) that `/[A-Z]/` doesn't detect.
 	hasUpperCasePattern.test(name)
 		? name.replaceAll(kebabPattern, '-').toLowerCase()
 		: name.toLowerCase()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,8 +28,9 @@ const hasUpperCasePattern = /[A-Z]/;
  * ```
  */
 export const flagNameToKebab = (name: string): string => (
-	// No uppercase means no boundary to split on, so skip the costly
-	// look-around regex; `toLowerCase()` alone matches its result.
+	// Skip the look-around regex when there's no ASCII uppercase to split on.
+	// `toLowerCase()` is still needed for non-ASCII uppercase (e.g. `İ`) that
+	// `/[A-Z]/` doesn't detect.
 	hasUpperCasePattern.test(name)
 		? name.replaceAll(kebabPattern, '-').toLowerCase()
 		: name.toLowerCase()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,7 @@ import { isStandardSchema, schemaToParser } from './standard-schema.ts';
  * - (?<=[A-Z])(?=[A-Z][a-z])  →  after uppercase, before uppercase+lowercase
  */
 const kebabPattern = /(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/g;
+const hasUpperCasePattern = /[A-Z]/;
 
 /**
  * Normalize a schema-declared flag name (e.g. `orgID`, `apiURL`, `fooBar`)
@@ -26,7 +27,13 @@ const kebabPattern = /(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/g;
  * flagNameToKebab('fooBar')        // => 'foo-bar'
  * ```
  */
-export const flagNameToKebab = (name: string): string => name.replaceAll(kebabPattern, '-').toLowerCase();
+export const flagNameToKebab = (name: string): string => (
+	// No uppercase means no boundary to split on, so skip the costly
+	// look-around regex; `toLowerCase()` alone matches its result.
+	hasUpperCasePattern.test(name)
+		? name.replaceAll(kebabPattern, '-').toLowerCase()
+		: name.toLowerCase()
+);
 
 const { hasOwnProperty } = Object.prototype;
 export const hasOwn = (


### PR DESCRIPTION
## Problem

`flagNameToKebab` runs a look-behind/look-ahead regex (`replaceAll`) on every flag name while building the registry — even for all-lowercase names that have no case boundary to split on. Profiling the parser (Bun `--cpu-prof-md`, 1M iterations of a 15-flag schema) showed this regex as the single largest addressable hot spot at **20.6% self-time**.

## Changes

Short-circuit the regex when a name contains no ASCII uppercase letter (the common case). When there's no `[A-Z]`, the look-around regex matches nothing, so `toLowerCase()` alone produces the identical result:

```ts
hasUpperCasePattern.test(name)
    ? name.replaceAll(kebabPattern, '-').toLowerCase()  // camelCase: real work
    : name.toLowerCase()                                // common case: skip the regex
```

Behavior-identical; internal only (no public API change).

## Impact

- Profile: kebab regex **20.6% → 6.4%** self-time; `createRegistry` total ~38% → ~2% (+ residual kebab for the camelCase names).
- Benchmark (`benchmarks/bench.js`, 3-lowercase-flag schema): ~1.8 µs → ~1.5 µs/iter.
- 192 tests pass; type-check, lint, build clean.

Note: real-world `typeFlag` calls build the registry once, so this is primarily a startup/throughput win that's amplified by the re-parse benchmark; `cleye` (which imports `flagNameToKebab`) also benefits.
