### PR TITLE
fix: split kebab-case on digit boundaries

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,16 +8,17 @@ import { isStandardSchema, schemaToParser } from './standard-schema.ts';
 
 /**
  * Regex uses zero-width assertions to find positions for hyphen insertion:
- * - (?<=[a-z])(?=[A-Z])  →  after lowercase, before uppercase
+ * - (?<=[a-z0-9])(?=[A-Z])  →  after lowercase or digit, before uppercase
  * - (?<=[A-Z])(?=[A-Z][a-z])  →  after uppercase, before uppercase+lowercase
  */
-const kebabPattern = /(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/g;
+const kebabPattern = /(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/g;
 const hasUpperCasePattern = /[A-Z]/;
 
 /**
- * Normalize a schema-declared flag name (e.g. `orgID`, `apiURL`, `fooBar`)
- * to the kebab-case form that matches argv tokens (`--org-id`, `--api-url`,
- * `--foo-bar`). Preserves acronyms as single segments.
+ * Normalize a schema-declared flag name (e.g. `orgID`, `apiURL`, `fooBar`,
+ * `oauth2Bearer`) to the kebab-case form that matches argv tokens
+ * (`--org-id`, `--api-url`, `--foo-bar`, `--oauth2-bearer`).
+ * Preserves acronyms as single segments.
  *
  * @example
  * ```ts
@@ -25,6 +26,7 @@ const hasUpperCasePattern = /[A-Z]/;
  * flagNameToKebab('apiURL')        // => 'api-url'
  * flagNameToKebab('parseJSONData') // => 'parse-json-data'
  * flagNameToKebab('fooBar')        // => 'foo-bar'
+ * flagNameToKebab('oauth2Bearer')  // => 'oauth2-bearer'
  * ```
  */
 export const flagNameToKebab = (name: string): string => (

--- a/tests/specs/flag-name-to-kebab/index.ts
+++ b/tests/specs/flag-name-to-kebab/index.ts
@@ -31,6 +31,23 @@ test('single word', () => {
 	expect(flagNameToKebab('simple')).toBe('simple');
 });
 
+test('digit before uppercase', () => {
+	expect(flagNameToKebab('oauth2Bearer')).toBe('oauth2-bearer');
+});
+
+test('acronym followed by digit then uppercase', () => {
+	expect(flagNameToKebab('openAPI3Key')).toBe('open-api3-key');
+});
+
+test('parses digit-boundary flag names from argv', () => {
+	const parsed = typeFlag({
+		oauth2Bearer: String,
+	}, [
+		'--oauth2-bearer=X',
+	]);
+	expect<string | undefined>(parsed.flags.oauth2Bearer).toBe('X');
+});
+
 test('parses acronym flag names from argv', () => {
 	const parsed = typeFlag({
 		orgID: String,


### PR DESCRIPTION
## Problem

`flagNameToKebab` only split on lowercase→uppercase and acronym→word boundaries, not digit→uppercase. So a flag like `oauth2Bearer` normalized to `oauth2bearer` instead of `oauth2-bearer`, and the natural argv form was unrecognized:

```
cli({ flags: { oauth2Bearer: { type: String } } }, undefined, ['--oauth2-bearer','X'])
  => flags.oauth2Bearer: undefined, unknownFlags: ["oauth2-bearer"]   // not recognized
```

Only the wrong spelling `--oauth2bearer` worked, as a side effect of the bug.

## Changes

Extend the first look-behind to include digits, so a digit acts like a lowercase letter for boundary purposes:

```ts
/(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/g
```

Now `oauth2Bearer → oauth2-bearer`, `openAPI3Key → open-api3-key`, etc. Acronym behavior is unchanged (`apiURL → api-url`, `parseJSONData → parse-json-data`).

The previously-recognized (incorrect) spelling `--oauth2bearer` stops working, since the generated alias is now `--oauth2-bearer`. This is the intended correction; the old form only "worked" because the conversion was wrong.
