### PR TITLE
feat: expose ordered `entries` argv stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,10 @@ Parser and framework integrations that need to rebuild this shape can use `creat
 
 ```ts
 const parsed = typeFlag({
-    data: { type: [String], alias: 'd' },
+    data: {
+        type: [String],
+        alias: 'd'
+    },
     dataUrlencode: [String]
 })
 

--- a/README.md
+++ b/README.md
@@ -379,6 +379,38 @@ For `['one', '--', 'two']`, `parsed._.slice()` is `['one', 'two']` and `parsed._
 
 Parser and framework integrations that need to rebuild this shape can use `createPositionalArguments()`; see the API reference below.
 
+### Consumed (command-line order)
+
+> [!NOTE]
+> Advanced. Most CLIs only need `flags`. Reach for `consumed` when the order of operations _across_ different flags matters.
+
+`flags` groups values by flag name, which discards how occurrences of different flags interleaved on the command line. `consumed` is the ordered stream of every interpreted argv element, so that relative order is preserved.
+
+```ts
+const parsed = typeFlag({
+    data: { type: [String], alias: 'd' },
+    dataUrlencode: [String]
+})
+
+// $ my-script -d a=1 --data-urlencode b=2 -d c=3
+parsed.flags // { data: ['a=1', 'c=3'], dataUrlencode: ['b=2'] }
+
+parsed.consumed
+// [
+//   { type: 'known-flag', name: 'data', value: 'a=1' },
+//   { type: 'known-flag', name: 'dataUrlencode', value: 'b=2' },
+//   { type: 'known-flag', name: 'data', value: 'c=3' }
+// ]
+```
+
+Each entry is discriminated by `type`:
+
+- `known-flag` — a flag defined in the schema. `name` is the **canonical schema key** (regardless of whether the alias, kebab-case, or camelCase form was used), and `value` is the parsed value for that single occurrence.
+- `unknown-flag` — a flag not in the schema. `name` is the raw argv name; `value` is the explicit value or `true`.
+- `argument` — a positional value. `afterDoubleDash` is `true` when it appeared after `--`.
+
+This is useful for curl-style data assembly (`-d` / `--data-urlencode` joined in argv order), debugging "which occurrence won", or any CLI where flags are an ordered instruction log rather than independent settings.
+
 ### Value Delimiters
 
 The characters `=`, `:`, and `.` delimit a value from a flag.

--- a/README.md
+++ b/README.md
@@ -379,12 +379,12 @@ For `['one', '--', 'two']`, `parsed._.slice()` is `['one', 'two']` and `parsed._
 
 Parser and framework integrations that need to rebuild this shape can use `createPositionalArguments()`; see the API reference below.
 
-### Consumed (command-line order)
+### Ordered Entries
 
 > [!NOTE]
-> Advanced. Most CLIs only need `flags`. Reach for `consumed` when the order of operations _across_ different flags matters.
+> Advanced. Most CLIs only need `flags`. Reach for `entries` when the order of operations _across_ different flags matters.
 
-`flags` groups values by flag name, which discards how occurrences of different flags interleaved on the command line. `consumed` is the ordered stream of every interpreted argv element, so that relative order is preserved.
+`flags` groups values by flag name, which discards how occurrences of different flags interleaved on the command line. `entries` is the ordered stream of every interpreted argv element, so that relative order is preserved.
 
 ```ts
 const parsed = typeFlag({
@@ -398,7 +398,7 @@ const parsed = typeFlag({
 // $ my-script -d a=1 --data-urlencode b=2 -d c=3
 parsed.flags // { data: ['a=1', 'c=3'], dataUrlencode: ['b=2'] }
 
-parsed.consumed
+parsed.entries
 // [
 //   { type: 'known-flag', name: 'data', value: 'a=1' },
 //   { type: 'known-flag', name: 'dataUrlencode', value: 'b=2' },
@@ -410,7 +410,9 @@ Each entry is discriminated by `type`:
 
 - `known-flag` — a flag defined in the schema. `name` is the **canonical schema key** (regardless of whether the alias, kebab-case, or camelCase form was used), and `value` is the parsed value for that single occurrence.
 - `unknown-flag` — a flag not in the schema. `name` is the raw argv name; `value` is the explicit value or `true`.
-- `argument` — a positional value. `afterDoubleDash` is `true` when it appeared after `--`.
+- `argument` — a positional value.
+
+Only parsed elements appear. Tokens after the `--` delimiter are not parsed, so they are excluded from `entries` — find them in [`_['--']`](#arguments-and---).
 
 This is useful for curl-style data assembly (`-d` / `--data-urlencode` joined in argv order), debugging "which occurrence won", or any CLI where flags are an ordered instruction log rather than independent settings.
 
@@ -588,11 +590,11 @@ type Parsed = {
     _: string[] & {
         '--': string[]
     }
-    consumed: ConsumedArgvItem[]
+    entries: ParsedArgvEntry[]
 }
 ```
 
-See [Consumed (command-line order)](#consumed-command-line-order) for the `ConsumedArgvItem` shape.
+See [Ordered Entries](#ordered-entries) for the `ParsedArgvEntry` shape.
 
 #### flagSchema
 

--- a/README.md
+++ b/README.md
@@ -395,14 +395,14 @@ const parsed = typeFlag({
     dataUrlencode: [String]
 })
 
-// $ my-script -d a=1 --data-urlencode b=2 -d c=3
-parsed.flags // { data: ['a=1', 'c=3'], dataUrlencode: ['b=2'] }
+// $ my-script -d a --data-urlencode b -d c
+parsed.flags // { data: ['a', 'c'], dataUrlencode: ['b'] }
 
 parsed.entries
 // [
-//   { type: 'known-flag', name: 'data', value: 'a=1' },
-//   { type: 'known-flag', name: 'dataUrlencode', value: 'b=2' },
-//   { type: 'known-flag', name: 'data', value: 'c=3' }
+//   { type: 'known-flag', name: 'data', value: 'a' },
+//   { type: 'known-flag', name: 'dataUrlencode', value: 'b' },
+//   { type: 'known-flag', name: 'data', value: 'c' }
 // ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -588,8 +588,11 @@ type Parsed = {
     _: string[] & {
         '--': string[]
     }
+    consumed: ConsumedArgvItem[]
 }
 ```
+
+See [Consumed (command-line order)](#consumed-command-line-order) for the `ConsumedArgvItem` shape.
 
 #### flagSchema
 

--- a/skills/type-flag/SKILL.md
+++ b/skills/type-flag/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: type-flag
-description: "Use when working with type-flag or building CLIs on top of it (e.g. cleye). Strongly-typed Node.js argv parser: schema syntax (String/Number/Boolean, arrays, custom parser functions, Standard Schema validators like Zod/Valibot/ArkType, aliases, defaults, single-char names), return shape (flags/unknownFlags/positional args, plus the advanced ordered `consumed` stream), flag forms (long/short/grouping, =/:/. delimiters, kebab/camelCase), boolean negation via `--no-`, and the `ignore` callback for multi-command dispatch."
+description: "Use when working with type-flag or building CLIs on top of it (e.g. cleye). Strongly-typed Node.js argv parser: schema syntax (String/Number/Boolean, arrays, custom parser functions, Standard Schema validators like Zod/Valibot/ArkType, aliases, defaults, single-char names), return shape (flags/unknownFlags/positional args, plus the advanced ordered `entries` stream), flag forms (long/short/grouping, =/:/. delimiters, kebab/camelCase), boolean negation via `--no-`, and the `ignore` callback for multi-command dispatch."
 ---
 
 # type-flag
@@ -78,22 +78,22 @@ typeFlag({
     flags:        { [name]: InferredType },
     unknownFlags: { [name]: (string | boolean)[] },  // not camelCased
     _:            string[] & { '--': string[] },      // positional; everything after `--` also in `_['--']`
-    consumed:     ConsumedArgvItem[],                 // advanced; see below
+    entries:      ParsedArgvEntry[],                  // advanced; see below
 }
 ```
 
-### `consumed` (advanced)
+### `entries` (advanced)
 
 Ordered stream of every interpreted argv element, preserving relative order across different flags (which `flags` discards by grouping per name). Most CLIs ignore this; use it when order across flags matters (e.g. curl `-d`/`--data-urlencode` body assembly).
 
 ```ts
-type ConsumedArgvItem =
+type ParsedArgvEntry =
     | { type: 'known-flag'; name: string; value: unknown }          // name = canonical schema key (alias/kebab resolved)
     | { type: 'unknown-flag'; name: string; value: string | boolean } // name = raw argv name
-    | { type: 'argument'; value: string; afterDoubleDash?: boolean }
+    | { type: 'argument'; value: string }
 ```
 
-`-d a=1 --data-urlencode b=2 -d c=3` → three `known-flag` items in argv order, each `name` being the canonical schema key. Ignored elements (via `ignore`) are excluded.
+`-d a=1 --data-urlencode b=2 -d c=3` → three `known-flag` items in argv order, each `name` being the canonical schema key. Ignored elements (via `ignore`) are excluded. Tokens after `--` are not parsed, so they don't appear here (use `_['--']`).
 
 ## Flag forms
 

--- a/skills/type-flag/SKILL.md
+++ b/skills/type-flag/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: type-flag
-description: "Use when working with type-flag or building CLIs on top of it (e.g. cleye). Strongly-typed Node.js argv parser: schema syntax (String/Number/Boolean, arrays, custom parser functions, Standard Schema validators like Zod/Valibot/ArkType, aliases, defaults, single-char names), return shape (flags/unknownFlags/positional args), flag forms (long/short/grouping, =/:/. delimiters, kebab/camelCase), boolean negation via `--no-`, and the `ignore` callback for multi-command dispatch."
+description: "Use when working with type-flag or building CLIs on top of it (e.g. cleye). Strongly-typed Node.js argv parser: schema syntax (String/Number/Boolean, arrays, custom parser functions, Standard Schema validators like Zod/Valibot/ArkType, aliases, defaults, single-char names), return shape (flags/unknownFlags/positional args, plus the advanced ordered `consumed` stream), flag forms (long/short/grouping, =/:/. delimiters, kebab/camelCase), boolean negation via `--no-`, and the `ignore` callback for multi-command dispatch."
 ---
 
 # type-flag
@@ -78,8 +78,22 @@ typeFlag({
     flags:        { [name]: InferredType },
     unknownFlags: { [name]: (string | boolean)[] },  // not camelCased
     _:            string[] & { '--': string[] },      // positional; everything after `--` also in `_['--']`
+    consumed:     ConsumedArgvItem[],                 // advanced; see below
 }
 ```
+
+### `consumed` (advanced)
+
+Ordered stream of every interpreted argv element, preserving relative order across different flags (which `flags` discards by grouping per name). Most CLIs ignore this; use it when order across flags matters (e.g. curl `-d`/`--data-urlencode` body assembly).
+
+```ts
+type ConsumedArgvItem =
+    | { type: 'known-flag'; name: string; value: unknown }          // name = canonical schema key (alias/kebab resolved)
+    | { type: 'unknown-flag'; name: string; value: string | boolean } // name = raw argv name
+    | { type: 'argument'; value: string; afterDoubleDash?: boolean }
+```
+
+`-d a=1 --data-urlencode b=2 -d c=3` → three `known-flag` items in argv order, each `name` being the canonical schema key. Ignored elements (via `ignore`) are excluded.
 
 ## Flag forms
 

--- a/skills/type-flag/SKILL.md
+++ b/skills/type-flag/SKILL.md
@@ -93,7 +93,7 @@ type ParsedArgvEntry =
     | { type: 'argument'; value: string }
 ```
 
-`-d a=1 --data-urlencode b=2 -d c=3` → three `known-flag` items in argv order, each `name` being the canonical schema key. Ignored elements (via `ignore`) are excluded. Tokens after `--` are not parsed, so they don't appear here (use `_['--']`).
+`-d a --data-urlencode b -d c` → three `known-flag` items in argv order, each `name` being the canonical schema key. Ignored elements (via `ignore`) are excluded. Tokens after `--` are not parsed, so they don't appear here (use `_['--']`).
 
 ## Flag forms
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,5 @@ export type {
 	Flags,
 	IgnoreFunction,
 	PositionalArguments,
-	ConsumedArgvItem,
+	ParsedArgvEntry,
 } from './types.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,5 @@ export type {
 	Flags,
 	IgnoreFunction,
 	PositionalArguments,
+	ConsumedArgvItem,
 } from './types.ts';

--- a/src/type-flag.ts
+++ b/src/type-flag.ts
@@ -3,18 +3,17 @@ import {
 	type TypeFlag,
 	type TypeFlagOptions,
 	type Simplify,
+	type ConsumedArgvItem,
 	KNOWN_FLAG,
 	UNKNOWN_FLAG,
 	ARGUMENT,
 } from './types.ts';
 import {
-	hasOwn,
 	createRegistry,
 	normalizeBoolean,
 	applyParser,
-	finalizeFlags,
+	finalizeParsed,
 } from './utils.ts';
-import { createPositionalArgumentsFromParts } from './positional-arguments.ts';
 import {
 	ALIAS_INDEX_LENGTH,
 	argvIterator,
@@ -49,17 +48,18 @@ export const typeFlag = <Schemas extends Flags>(
 ) => {
 	const removeArgvs: Index[] = [];
 	const flagRegistry = createRegistry(schemas);
-	const unknownFlags: TypeFlag['unknownFlags'] = {};
-	const positionals: string[] = [];
-	let doubleDashArguments: string[] = [];
 
-	// Pending value-expecting flag, read by `flushFlagValue`. Hoisted so
-	// value-taking flags don't allocate a callback closure per occurrence
-	// (and keep the value-delivery call site monomorphic).
-	let pendingValues: unknown[];
+	// The ordered, interpreted argv stream — the single source of truth that
+	// `flags`, `unknownFlags`, and `_` are all derived from.
+	const consumed: ConsumedArgvItem[] = [];
+
+	// Pending value-expecting flag, read by `flushFlagValue` when the next token
+	// arrives. Hoisted so value-taking flags don't allocate a callback closure
+	// per occurrence (and keep the value-delivery call site monomorphic).
+	let pendingName: string;
 	let pendingParser: Parameters<typeof applyParser>[0];
 	let pendingFlagIndex: Index;
-	let pendingName: string;
+	let pendingRawName: string;
 
 	const flushFlagValue = (
 		value: string | boolean | undefined,
@@ -71,7 +71,11 @@ export const typeFlag = <Schemas extends Flags>(
 			removeArgvs.push(valueIndex);
 		}
 
-		pendingValues.push(applyParser(pendingParser, value || '', pendingName));
+		consumed.push({
+			type: KNOWN_FLAG,
+			name: pendingName,
+			value: applyParser(pendingParser, value || '', pendingRawName),
+		});
 	};
 
 	argvIterator(argv, {
@@ -82,7 +86,7 @@ export const typeFlag = <Schemas extends Flags>(
 			const isValid = isAlias || name.length > 1;
 			const flagData = isValid ? flagRegistry.get(name) : undefined;
 
-			let negatedBaseValues: unknown[] | undefined;
+			let negatedBaseName: string | undefined;
 			if (
 				!flagData
 				&& booleanNegation
@@ -92,13 +96,13 @@ export const typeFlag = <Schemas extends Flags>(
 			) {
 				const baseData = flagRegistry.get(name.slice(3));
 				if (baseData && baseData[1] === Boolean) {
-					negatedBaseValues = baseData[0];
+					[negatedBaseName] = baseData;
 				}
 			}
 
 			if (
 				ignore?.(
-					flagData || negatedBaseValues ? KNOWN_FLAG : UNKNOWN_FLAG,
+					flagData || negatedBaseName ? KNOWN_FLAG : UNKNOWN_FLAG,
 					name,
 					explicitValue,
 				)
@@ -107,11 +111,11 @@ export const typeFlag = <Schemas extends Flags>(
 			}
 
 			if (flagData) {
-				const [values, parser] = flagData;
-				pendingValues = values;
+				const [canonicalName, parser] = flagData;
+				pendingName = canonicalName;
 				pendingParser = parser;
 				pendingFlagIndex = flagIndex;
-				pendingName = name;
+				pendingRawName = name;
 
 				const flagValue = normalizeBoolean(parser, explicitValue);
 				if (flagValue === undefined) {
@@ -123,19 +127,21 @@ export const typeFlag = <Schemas extends Flags>(
 				return;
 			}
 
-			if (negatedBaseValues) {
-				negatedBaseValues.push(false);
+			if (negatedBaseName) {
+				consumed.push({
+					type: KNOWN_FLAG,
+					name: negatedBaseName,
+					value: false,
+				});
 				removeArgvs.push(flagIndex);
 				return;
 			}
 
-			if (!hasOwn(unknownFlags, name)) {
-				unknownFlags[name] = [];
-			}
-
-			unknownFlags[name].push(
-				explicitValue === undefined ? true : explicitValue,
-			);
+			consumed.push({
+				type: UNKNOWN_FLAG,
+				name,
+				value: explicitValue === undefined ? true : explicitValue,
+			});
 			removeArgvs.push(flagIndex);
 		},
 
@@ -146,10 +152,22 @@ export const typeFlag = <Schemas extends Flags>(
 				return;
 			}
 
-			positionals.push(...args);
+			for (const value of args) {
+				consumed.push(
+					isEoF
+						? {
+							type: ARGUMENT,
+							value,
+							afterDoubleDash: true,
+						}
+						: {
+							type: ARGUMENT,
+							value,
+						},
+				);
+			}
 
 			if (isEoF) {
-				doubleDashArguments = args;
 				argv.splice(index[0]);
 			} else {
 				removeArgvs.push(index);
@@ -160,8 +178,7 @@ export const typeFlag = <Schemas extends Flags>(
 	spliceFromArgv(argv, removeArgvs);
 
 	return {
-		flags: finalizeFlags(schemas, flagRegistry),
-		unknownFlags,
-		_: createPositionalArgumentsFromParts(positionals, doubleDashArguments),
+		...finalizeParsed(schemas, flagRegistry, consumed),
+		consumed,
 	} as Simplify<TypeFlag<Schemas>>;
 };

--- a/src/type-flag.ts
+++ b/src/type-flag.ts
@@ -3,7 +3,7 @@ import {
 	type TypeFlag,
 	type TypeFlagOptions,
 	type Simplify,
-	type ConsumedArgvItem,
+	type ParsedArgvEntry,
 	KNOWN_FLAG,
 	UNKNOWN_FLAG,
 	ARGUMENT,
@@ -50,8 +50,12 @@ export const typeFlag = <Schemas extends Flags>(
 	const flagRegistry = createRegistry(schemas);
 
 	// The ordered, interpreted argv stream — the single source of truth that
-	// `flags`, `unknownFlags`, and `_` are all derived from.
-	const consumed: ConsumedArgvItem[] = [];
+	// `flags`, `unknownFlags`, and pre-`--` positionals are derived from.
+	const entries: ParsedArgvEntry[] = [];
+
+	// Raw tokens after the `--` delimiter. Not parsed (so not in `entries`);
+	// surfaced only via `_['--']`.
+	let doubleDashArguments: string[] = [];
 
 	// Pending value-expecting flag, read by `flushFlagValue` when the next token
 	// arrives. Hoisted so value-taking flags don't allocate a callback closure
@@ -71,7 +75,7 @@ export const typeFlag = <Schemas extends Flags>(
 			removeArgvs.push(valueIndex);
 		}
 
-		consumed.push({
+		entries.push({
 			type: KNOWN_FLAG,
 			name: pendingName,
 			value: applyParser(pendingParser, value || '', pendingRawName),
@@ -128,7 +132,7 @@ export const typeFlag = <Schemas extends Flags>(
 			}
 
 			if (negatedBaseName) {
-				consumed.push({
+				entries.push({
 					type: KNOWN_FLAG,
 					name: negatedBaseName,
 					value: false,
@@ -137,7 +141,7 @@ export const typeFlag = <Schemas extends Flags>(
 				return;
 			}
 
-			consumed.push({
+			entries.push({
 				type: UNKNOWN_FLAG,
 				name,
 				value: explicitValue === undefined ? true : explicitValue,
@@ -152,33 +156,29 @@ export const typeFlag = <Schemas extends Flags>(
 				return;
 			}
 
-			for (const value of args) {
-				consumed.push(
-					isEoF
-						? {
-							type: ARGUMENT,
-							value,
-							afterDoubleDash: true,
-						}
-						: {
-							type: ARGUMENT,
-							value,
-						},
-				);
+			// Tokens after `--` aren't parsed — keep them out of `entries` and
+			// expose them only through `_['--']`.
+			if (isEoF) {
+				doubleDashArguments = args;
+				argv.splice(index[0]);
+				return;
 			}
 
-			if (isEoF) {
-				argv.splice(index[0]);
-			} else {
-				removeArgvs.push(index);
+			for (const value of args) {
+				entries.push({
+					type: ARGUMENT,
+					value,
+				});
 			}
+
+			removeArgvs.push(index);
 		},
 	});
 
 	spliceFromArgv(argv, removeArgvs);
 
 	return {
-		...finalizeParsed(schemas, flagRegistry, consumed),
-		consumed,
+		...finalizeParsed(schemas, flagRegistry, entries, doubleDashArguments),
+		entries,
 	} as Simplify<TypeFlag<Schemas>>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,11 +213,14 @@ export type TypeFlag<Schemas extends Flags = Flags> = {
 	 * line. Unlike `flags` (which groups values by flag name), this preserves the
 	 * relative order across different flags and positional arguments.
 	 *
-	 * Advanced: most CLIs only need `flags`. Reach for `consumed` when the order
+	 * Only covers what the parser interprets: elements after the `--` delimiter
+	 * are not parsed, so they are excluded here (find them in `_['--']`).
+	 *
+	 * Advanced: most CLIs only need `flags`. Reach for `entries` when the order
 	 * of operations across different flags matters — e.g. assembling a curl-style
 	 * request body from interleaved `-d` and `--data-urlencode`.
 	 */
-	consumed: ConsumedArgvItem[];
+	entries: ParsedArgvEntry[];
 };
 
 /** Constant indicating a known flag token type. */
@@ -230,10 +233,10 @@ export const UNKNOWN_FLAG = 'unknown-flag';
 export const ARGUMENT = 'argument';
 
 /**
- * A single interpreted argv element from {@link TypeFlag.consumed}, discriminated
+ * A single interpreted argv element from {@link TypeFlag.entries}, discriminated
  * by `type`.
  */
-export type ConsumedArgvItem =
+export type ParsedArgvEntry =
 	| {
 		type: typeof KNOWN_FLAG;
 
@@ -261,9 +264,6 @@ export type ConsumedArgvItem =
 
 		/** The positional argument value. */
 		value: string;
-
-		/** `true` when the argument appeared after the `--` delimiter. */
-		afterDoubleDash?: boolean;
 	};
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,6 +207,17 @@ export type TypeFlag<Schemas extends Flags = Flags> = {
 	 * Includes a special `"--"` key for arguments after the double dash.
 	 */
 	_: PositionalArguments;
+
+	/**
+	 * Every interpreted argv element, in the order it appeared on the command
+	 * line. Unlike `flags` (which groups values by flag name), this preserves the
+	 * relative order across different flags and positional arguments.
+	 *
+	 * Advanced: most CLIs only need `flags`. Reach for `consumed` when the order
+	 * of operations across different flags matters — e.g. assembling a curl-style
+	 * request body from interleaved `-d` and `--data-urlencode`.
+	 */
+	consumed: ConsumedArgvItem[];
 };
 
 /** Constant indicating a known flag token type. */
@@ -217,6 +228,43 @@ export const UNKNOWN_FLAG = 'unknown-flag';
 
 /** Constant indicating a positional argument token type. */
 export const ARGUMENT = 'argument';
+
+/**
+ * A single interpreted argv element from {@link TypeFlag.consumed}, discriminated
+ * by `type`.
+ */
+export type ConsumedArgvItem =
+	| {
+		type: typeof KNOWN_FLAG;
+
+		/**
+		 * Canonical schema key — always the name as declared in the schema
+		 * (e.g. `dataUrlencode`), regardless of whether the alias (`-d`),
+		 * kebab-case (`--data-urlencode`), or camelCase form was used in argv.
+		 */
+		name: string;
+
+		/** Parsed value for this single occurrence. */
+		value: unknown;
+	}
+	| {
+		type: typeof UNKNOWN_FLAG;
+
+		/** Raw flag name as it appeared in argv (not camelCased). */
+		name: string;
+
+		/** Explicit value, or `true` when the flag had no value. */
+		value: string | boolean;
+	}
+	| {
+		type: typeof ARGUMENT;
+
+		/** The positional argument value. */
+		value: string;
+
+		/** `true` when the argument appeared after the `--` delimiter. */
+		afterDoubleDash?: boolean;
+	};
 
 /**
  * A function to dynamically ignore specific elements during parsing.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import {
 	type FlagTypeOrSchema,
 	type Flags,
 	type FlagSchema,
-	type ConsumedArgvItem,
+	type ParsedArgvEntry,
 	KNOWN_FLAG,
 	UNKNOWN_FLAG,
 } from './types.ts';
@@ -189,36 +189,32 @@ export const createRegistry = (
 };
 
 /**
- * Bucket the ordered `consumed` stream by item kind: known-flag values grouped
- * by canonical name (order preserved), unknown flags grouped by raw name, and
- * positionals (tracking which appeared after `--`).
+ * Bucket the ordered `entries` stream by kind: known-flag values grouped by
+ * canonical name (order preserved), unknown flags grouped by raw name, and
+ * positional arguments. Post-`--` tokens are not in `entries`.
  */
-const groupConsumed = (
-	consumed: ConsumedArgvItem[],
+const groupEntries = (
+	entries: ParsedArgvEntry[],
 ) => {
 	const knownFlagValues = new Map<string, unknown[]>();
 	const unknownFlags: Record<string, (string | boolean)[]> = {};
 	const positionals: string[] = [];
-	const doubleDashArguments: string[] = [];
 
-	for (const item of consumed) {
-		if (item.type === KNOWN_FLAG) {
-			let values = knownFlagValues.get(item.name);
+	for (const entry of entries) {
+		if (entry.type === KNOWN_FLAG) {
+			let values = knownFlagValues.get(entry.name);
 			if (!values) {
 				values = [];
-				knownFlagValues.set(item.name, values);
+				knownFlagValues.set(entry.name, values);
 			}
-			values.push(item.value);
-		} else if (item.type === UNKNOWN_FLAG) {
-			if (!hasOwn(unknownFlags, item.name)) {
-				unknownFlags[item.name] = [];
+			values.push(entry.value);
+		} else if (entry.type === UNKNOWN_FLAG) {
+			if (!hasOwn(unknownFlags, entry.name)) {
+				unknownFlags[entry.name] = [];
 			}
-			unknownFlags[item.name].push(item.value);
+			unknownFlags[entry.name].push(entry.value);
 		} else {
-			positionals.push(item.value);
-			if (item.afterDoubleDash) {
-				doubleDashArguments.push(item.value);
-			}
+			positionals.push(entry.value);
 		}
 	}
 
@@ -226,7 +222,6 @@ const groupConsumed = (
 		knownFlagValues,
 		unknownFlags,
 		positionals,
-		doubleDashArguments,
 	};
 };
 
@@ -260,19 +255,20 @@ const resolveFlagValue = (
 
 /**
  * Derive the public result (`flags`, `unknownFlags`, `_`) from the ordered
- * `consumed` stream — the parser's single source of truth.
+ * `entries` stream — the parser's single source of truth — plus the raw
+ * post-`--` tail (which is not parsed into `entries`).
  */
 export const finalizeParsed = (
 	schemas: Flags,
 	registry: FlagRegistry,
-	consumed: ConsumedArgvItem[],
+	entries: ParsedArgvEntry[],
+	doubleDashArguments: string[],
 ) => {
 	const {
 		knownFlagValues,
 		unknownFlags,
 		positionals,
-		doubleDashArguments,
-	} = groupConsumed(consumed);
+	} = groupEntries(entries);
 
 	const flags: Record<string, unknown> = {};
 	for (const flagName in schemas) {
@@ -295,6 +291,9 @@ export const finalizeParsed = (
 	return {
 		flags,
 		unknownFlags,
-		_: createPositionalArgumentsFromParts(positionals, doubleDashArguments),
+		_: createPositionalArgumentsFromParts(
+			[...positionals, ...doubleDashArguments],
+			doubleDashArguments,
+		),
 	};
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,14 @@
-import type {
-	TypeFunction,
-	FlagTypeOrSchema,
-	Flags,
-	FlagSchema,
+import {
+	type TypeFunction,
+	type FlagTypeOrSchema,
+	type Flags,
+	type FlagSchema,
+	type ConsumedArgvItem,
+	KNOWN_FLAG,
+	UNKNOWN_FLAG,
 } from './types.ts';
 import { isStandardSchema, schemaToParser } from './standard-schema.ts';
+import { createPositionalArgumentsFromParts } from './positional-arguments.ts';
 
 /**
  * Regex uses zero-width assertions to find positions for hyphen insertion:
@@ -115,14 +119,14 @@ const validateFlagName = (
 	}
 };
 
-type FlagParsingData = [
-	values: unknown[],
+export type FlagParsingData = [
+	name: string,
 	parser: TypeFunction,
 	isArray: boolean,
 	schema: FlagTypeOrSchema,
 ];
 
-type FlagRegistry = Map<string, FlagParsingData>;
+export type FlagRegistry = Map<string, FlagParsingData>;
 
 const setFlag = (
 	registry: FlagRegistry,
@@ -149,7 +153,7 @@ export const createRegistry = (
 
 		const schema = schemas[flagName];
 		const flagData: FlagParsingData = [
-			[],
+			flagName,
 			...parseFlagType(schema),
 			schema,
 		];
@@ -184,12 +188,93 @@ export const createRegistry = (
 	return registry;
 };
 
-export const finalizeFlags = (
+/**
+ * Bucket the ordered `consumed` stream by item kind: known-flag values grouped
+ * by canonical name (order preserved), unknown flags grouped by raw name, and
+ * positionals (tracking which appeared after `--`).
+ */
+const groupConsumed = (
+	consumed: ConsumedArgvItem[],
+) => {
+	const knownFlagValues = new Map<string, unknown[]>();
+	const unknownFlags: Record<string, (string | boolean)[]> = {};
+	const positionals: string[] = [];
+	const doubleDashArguments: string[] = [];
+
+	for (const item of consumed) {
+		if (item.type === KNOWN_FLAG) {
+			let values = knownFlagValues.get(item.name);
+			if (!values) {
+				values = [];
+				knownFlagValues.set(item.name, values);
+			}
+			values.push(item.value);
+		} else if (item.type === UNKNOWN_FLAG) {
+			if (!hasOwn(unknownFlags, item.name)) {
+				unknownFlags[item.name] = [];
+			}
+			unknownFlags[item.name].push(item.value);
+		} else {
+			positionals.push(item.value);
+			if (item.afterDoubleDash) {
+				doubleDashArguments.push(item.value);
+			}
+		}
+	}
+
+	return {
+		knownFlagValues,
+		unknownFlags,
+		positionals,
+		doubleDashArguments,
+	};
+};
+
+/**
+ * Resolve a single flag's final value from its collected occurrences: fall back
+ * to the schema default when absent, return the full array for array flags, or
+ * the last occurrence for scalar flags (last-wins).
+ */
+const resolveFlagValue = (
+	schema: FlagTypeOrSchema,
+	isArray: boolean,
+	values: unknown[] | undefined,
+) => {
+	if (
+		(!values || values.length === 0)
+		// A raw schema (e.g. Zod, ArkType) can have its own `.default`; only a
+		// flag-schema object's `default` is a type-flag default.
+		&& !isStandardSchema(schema)
+		&& 'default' in schema
+	) {
+		const { default: defaultValue } = schema;
+		return typeof defaultValue === 'function' ? defaultValue() : defaultValue;
+	}
+
+	if (isArray) {
+		return values ?? [];
+	}
+
+	return values && values.at(-1);
+};
+
+/**
+ * Derive the public result (`flags`, `unknownFlags`, `_`) from the ordered
+ * `consumed` stream — the parser's single source of truth.
+ */
+export const finalizeParsed = (
 	schemas: Flags,
 	registry: FlagRegistry,
+	consumed: ConsumedArgvItem[],
 ) => {
-	const flags: Record<string, unknown> = {};
+	const {
+		knownFlagValues,
+		unknownFlags,
+		positionals,
+		doubleDashArguments,
+	} = groupConsumed(consumed);
 
+	const flags: Record<string, unknown> = {};
 	for (const flagName in schemas) {
 		if (!hasOwn(schemas, flagName)) {
 			continue;
@@ -200,23 +285,16 @@ export const finalizeFlags = (
 			continue;
 		}
 
-		const [values, , isArray, schema] = flagData;
-		if (
-			values.length === 0
-			// A raw schema (e.g. Zod, ArkType) can have its own `.default`; only a
-			// flag-schema object's `default` is a type-flag default.
-			&& !isStandardSchema(schema)
-			&& 'default' in schema
-		) {
-			let { default: defaultValue } = schema;
-			if (typeof defaultValue === 'function') {
-				defaultValue = defaultValue();
-			}
-			flags[flagName] = defaultValue;
-		} else {
-			flags[flagName] = isArray ? values : values.pop();
-		}
+		flags[flagName] = resolveFlagValue(
+			flagData[3],
+			flagData[2],
+			knownFlagValues.get(flagName),
+		);
 	}
 
-	return flags;
+	return {
+		flags,
+		unknownFlags,
+		_: createPositionalArgumentsFromParts(positionals, doubleDashArguments),
+	};
 };

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -1578,7 +1578,7 @@ describe('Parsing', () => {
 		});
 	});
 
-	describe('consumed', () => {
+	describe('entries', () => {
 		test('preserves order across different flags', () => {
 			const parsed = typeFlag(
 				{
@@ -1597,8 +1597,8 @@ describe('Parsing', () => {
 				dataUrlencode: ['b=2'],
 			});
 
-			// ...but `consumed` preserves the command-line order.
-			expect(parsed.consumed).toStrictEqual([
+			// ...but `entries` preserves the command-line order.
+			expect(parsed.entries).toStrictEqual([
 				{
 					type: 'known-flag',
 					name: 'data',
@@ -1628,7 +1628,7 @@ describe('Parsing', () => {
 				['-d', 'a', '--data-urlencode', 'b', '--dataUrlencode', 'c'],
 			);
 
-			expect(parsed.consumed).toStrictEqual([
+			expect(parsed.entries).toStrictEqual([
 				{
 					type: 'known-flag',
 					name: 'dataUrlencode',
@@ -1656,7 +1656,7 @@ describe('Parsing', () => {
 				['--port', '3000', '--verbose', '--port=3001'],
 			);
 
-			expect(parsed.consumed).toStrictEqual([
+			expect(parsed.entries).toStrictEqual([
 				{
 					type: 'known-flag',
 					name: 'port',
@@ -1682,7 +1682,7 @@ describe('Parsing', () => {
 			);
 
 			expect(parsed.flags.name).toBe('b');
-			expect(parsed.consumed).toStrictEqual([
+			expect(parsed.entries).toStrictEqual([
 				{
 					type: 'known-flag',
 					name: 'name',
@@ -1702,7 +1702,7 @@ describe('Parsing', () => {
 				['file.txt', '--verbose', '--unknown=x', 'other.txt'],
 			);
 
-			expect(parsed.consumed).toStrictEqual([
+			expect(parsed.entries).toStrictEqual([
 				{
 					type: 'argument',
 					value: 'file.txt',
@@ -1724,13 +1724,14 @@ describe('Parsing', () => {
 			]);
 		});
 
-		test('flags arguments after the double-dash delimiter', () => {
+		test('excludes tokens after the double-dash delimiter (they are not parsed)', () => {
 			const parsed = typeFlag(
 				{ verbose: Boolean },
 				['a', '--verbose', '--', 'b', 'c'],
 			);
 
-			expect(parsed.consumed).toStrictEqual([
+			// Only pre-`--` elements are interpreted, so `entries` stops at `--`.
+			expect(parsed.entries).toStrictEqual([
 				{
 					type: 'argument',
 					value: 'a',
@@ -1740,17 +1741,10 @@ describe('Parsing', () => {
 					name: 'verbose',
 					value: true,
 				},
-				{
-					type: 'argument',
-					value: 'b',
-					afterDoubleDash: true,
-				},
-				{
-					type: 'argument',
-					value: 'c',
-					afterDoubleDash: true,
-				},
 			]);
+
+			// The raw post-`--` tail remains available through `_`.
+			expect(parsed._).toStrictEqual(Object.assign(['a', 'b', 'c'], { '--': ['b', 'c'] }));
 		});
 
 		test('records boolean negation as the canonical flag set to false', () => {
@@ -1761,7 +1755,7 @@ describe('Parsing', () => {
 			);
 
 			expect(parsed.flags.cache).toBe(false);
-			expect(parsed.consumed).toStrictEqual([
+			expect(parsed.entries).toStrictEqual([
 				{
 					type: 'known-flag',
 					name: 'cache',
@@ -1788,8 +1782,8 @@ describe('Parsing', () => {
 			);
 
 			// An ignored flag never consumes a following value, so `a`/`b` fall
-			// through as positional arguments — and `consumed` reflects exactly that.
-			expect(parsed.consumed).toStrictEqual([
+			// through as positional arguments — and `entries` reflects exactly that.
+			expect(parsed.entries).toStrictEqual([
 				{
 					type: 'argument',
 					value: 'a',

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -99,23 +99,17 @@ describe('Parsing', () => {
 				{}, ['-invalidAlias'],
 			);
 
-			expect<{
-				_: string[] & { '--': string[] };
-				flags: Record<PropertyKey, never>;
-				unknownFlags: Record<string, (string | boolean)[]>;
-			}>(parsed).toStrictEqual({
-				_: Object.assign([], { '--': [] }),
-				flags: {},
-				unknownFlags: {
-					i: [true, true, true],
-					n: [true],
-					v: [true],
-					a: [true, true],
-					l: [true, true],
-					d: [true],
-					A: [true],
-					s: [true],
-				},
+			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(Object.assign([], { '--': [] }));
+			expect<Record<PropertyKey, never>>(parsed.flags).toStrictEqual({});
+			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({
+				i: [true, true, true],
+				n: [true],
+				v: [true],
+				a: [true, true],
+				l: [true, true],
+				d: [true],
+				A: [true],
+				s: [true],
 			});
 		});
 
@@ -1176,26 +1170,18 @@ describe('Parsing', () => {
 				},
 			);
 
-			expect<{
-				flags: {
-					string: string[];
-				};
-				unknownFlags: Record<string, (string | boolean)[]>;
-				_: string[] & { '--': string[] };
-			}>(parsed).toStrictEqual({
-				flags: {
-					string: [],
-				},
-				unknownFlags: {
-					unknown: [true, 'd'],
-					u: [true],
-					v: [true, true, '1'],
-				},
-				_: Object.assign(
-					['a', 'c'],
-					{ '--': [] },
-				),
+			expect<{ string: string[] }>(parsed.flags).toStrictEqual({
+				string: [],
 			});
+			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({
+				unknown: [true, 'd'],
+				u: [true],
+				v: [true, true, '1'],
+			});
+			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(Object.assign(
+				['a', 'c'],
+				{ '--': [] },
+			));
 			expect<string[]>(argv).toStrictEqual(['--string', '--string=b']);
 		});
 
@@ -1218,24 +1204,16 @@ describe('Parsing', () => {
 				},
 			);
 
-			expect<{
-				flags: {
-					string: string[];
-					boolean: boolean | undefined;
-				};
-				unknownFlags: Record<string, (string | boolean)[]>;
-				_: string[] & { '--': string[] };
-			}>(parsed).toStrictEqual({
-				flags: {
-					string: ['a', 'b', 'd'],
-					boolean: true,
-				},
-				unknownFlags: {},
-				_: Object.assign(
-					['c'],
-					{ '--': [] },
-				),
+			expect<{ string: string[];
+				boolean: boolean | undefined; }>(parsed.flags).toStrictEqual({
+				string: ['a', 'b', 'd'],
+				boolean: true,
 			});
+			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({});
+			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(Object.assign(
+				['c'],
+				{ '--': [] },
+			));
 			expect<string[]>(argv).toStrictEqual(['--unknown', '--unknown=d', '-u', '-vv=1', '-u']);
 		});
 
@@ -1263,22 +1241,14 @@ describe('Parsing', () => {
 				},
 			);
 
-			expect<{
-				flags: {
-					string: string[];
-				};
-				unknownFlags: Record<string, (string | boolean)[]>;
-				_: string[] & { '--': string[] };
-			}>(parsed).toStrictEqual({
-				flags: {
-					string: ['value'],
-				},
-				unknownFlags: {},
-				_: Object.assign(
-					[],
-					{ '--': [] },
-				),
+			expect<{ string: string[] }>(parsed.flags).toStrictEqual({
+				string: ['value'],
 			});
+			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({});
+			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(Object.assign(
+				[],
+				{ '--': [] },
+			));
 			expect<string[]>(argv).toStrictEqual(['first-arg', '--string=b', '--string', 'c', '--unknown=d', '-u', '--', 'hello']);
 		});
 
@@ -1301,24 +1271,16 @@ describe('Parsing', () => {
 				},
 			);
 
-			expect<{
-				flags: {
-					string: string | undefined;
-					boolean: boolean | undefined;
-				};
-				unknownFlags: Record<string, (string | boolean)[]>;
-				_: string[] & { '--': string[] };
-			}>(parsed).toStrictEqual({
-				flags: {
-					string: 'hello',
-					boolean: undefined,
-				},
-				unknownFlags: {},
-				_: Object.assign(
-					['a'],
-					{ '--': [] },
-				),
+			expect<{ string: string | undefined;
+				boolean: boolean | undefined; }>(parsed.flags).toStrictEqual({
+				string: 'hello',
+				boolean: undefined,
 			});
+			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({});
+			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(Object.assign(
+				['a'],
+				{ '--': [] },
+			));
 			expect<string[]>(argv).toStrictEqual(['--', 'b', '--string=b', '--unknown', '--boolean']);
 		});
 
@@ -1613,6 +1575,235 @@ describe('Parsing', () => {
 			expect<string | number>(parsed.flags.inconsistentTypesC).toBe('world');
 			expect<string[]>(parsed.flags.noDefault).toStrictEqual([]);
 			expect<string[]>(argv).toStrictEqual([]);
+		});
+	});
+
+	describe('consumed', () => {
+		test('preserves order across different flags', () => {
+			const parsed = typeFlag(
+				{
+					data: {
+						type: [String],
+						alias: 'd',
+					},
+					dataUrlencode: [String],
+				},
+				['-d', 'a=1', '--data-urlencode', 'b=2', '-d', 'c=3'],
+			);
+
+			// `flags` groups by name, losing the interleaving...
+			expect(parsed.flags).toStrictEqual({
+				data: ['a=1', 'c=3'],
+				dataUrlencode: ['b=2'],
+			});
+
+			// ...but `consumed` preserves the command-line order.
+			expect(parsed.consumed).toStrictEqual([
+				{
+					type: 'known-flag',
+					name: 'data',
+					value: 'a=1',
+				},
+				{
+					type: 'known-flag',
+					name: 'dataUrlencode',
+					value: 'b=2',
+				},
+				{
+					type: 'known-flag',
+					name: 'data',
+					value: 'c=3',
+				},
+			]);
+		});
+
+		test('uses the canonical schema name for alias and kebab-case input', () => {
+			const parsed = typeFlag(
+				{
+					dataUrlencode: {
+						type: [String],
+						alias: 'd',
+					},
+				},
+				['-d', 'a', '--data-urlencode', 'b', '--dataUrlencode', 'c'],
+			);
+
+			expect(parsed.consumed).toStrictEqual([
+				{
+					type: 'known-flag',
+					name: 'dataUrlencode',
+					value: 'a',
+				},
+				{
+					type: 'known-flag',
+					name: 'dataUrlencode',
+					value: 'b',
+				},
+				{
+					type: 'known-flag',
+					name: 'dataUrlencode',
+					value: 'c',
+				},
+			]);
+		});
+
+		test('parses values and applies the type function', () => {
+			const parsed = typeFlag(
+				{
+					port: [Number],
+					verbose: Boolean,
+				},
+				['--port', '3000', '--verbose', '--port=3001'],
+			);
+
+			expect(parsed.consumed).toStrictEqual([
+				{
+					type: 'known-flag',
+					name: 'port',
+					value: 3000,
+				},
+				{
+					type: 'known-flag',
+					name: 'verbose',
+					value: true,
+				},
+				{
+					type: 'known-flag',
+					name: 'port',
+					value: 3001,
+				},
+			]);
+		});
+
+		test('includes every occurrence of a scalar flag (last wins in flags)', () => {
+			const parsed = typeFlag(
+				{ name: String },
+				['--name', 'a', '--name', 'b'],
+			);
+
+			expect(parsed.flags.name).toBe('b');
+			expect(parsed.consumed).toStrictEqual([
+				{
+					type: 'known-flag',
+					name: 'name',
+					value: 'a',
+				},
+				{
+					type: 'known-flag',
+					name: 'name',
+					value: 'b',
+				},
+			]);
+		});
+
+		test('records unknown flags and positionals in order', () => {
+			const parsed = typeFlag(
+				{ verbose: Boolean },
+				['file.txt', '--verbose', '--unknown=x', 'other.txt'],
+			);
+
+			expect(parsed.consumed).toStrictEqual([
+				{
+					type: 'argument',
+					value: 'file.txt',
+				},
+				{
+					type: 'known-flag',
+					name: 'verbose',
+					value: true,
+				},
+				{
+					type: 'unknown-flag',
+					name: 'unknown',
+					value: 'x',
+				},
+				{
+					type: 'argument',
+					value: 'other.txt',
+				},
+			]);
+		});
+
+		test('flags arguments after the double-dash delimiter', () => {
+			const parsed = typeFlag(
+				{ verbose: Boolean },
+				['a', '--verbose', '--', 'b', 'c'],
+			);
+
+			expect(parsed.consumed).toStrictEqual([
+				{
+					type: 'argument',
+					value: 'a',
+				},
+				{
+					type: 'known-flag',
+					name: 'verbose',
+					value: true,
+				},
+				{
+					type: 'argument',
+					value: 'b',
+					afterDoubleDash: true,
+				},
+				{
+					type: 'argument',
+					value: 'c',
+					afterDoubleDash: true,
+				},
+			]);
+		});
+
+		test('records boolean negation as the canonical flag set to false', () => {
+			const parsed = typeFlag(
+				{ cache: Boolean },
+				['--cache', '--no-cache'],
+				{ booleanNegation: true },
+			);
+
+			expect(parsed.flags.cache).toBe(false);
+			expect(parsed.consumed).toStrictEqual([
+				{
+					type: 'known-flag',
+					name: 'cache',
+					value: true,
+				},
+				{
+					type: 'known-flag',
+					name: 'cache',
+					value: false,
+				},
+			]);
+		});
+
+		test('excludes elements skipped by the ignore callback', () => {
+			const parsed = typeFlag(
+				{
+					string: [String],
+					verbose: Boolean,
+				},
+				['--string', 'a', '--verbose', '--string', 'b'],
+				{
+					ignore: (type, flagName) => type === 'known-flag' && flagName === 'string',
+				},
+			);
+
+			// An ignored flag never consumes a following value, so `a`/`b` fall
+			// through as positional arguments — and `consumed` reflects exactly that.
+			expect(parsed.consumed).toStrictEqual([
+				{
+					type: 'argument',
+					value: 'a',
+				},
+				{
+					type: 'known-flag',
+					name: 'verbose',
+					value: true,
+				},
+				{
+					type: 'argument',
+					value: 'b',
+				},
+			]);
 		});
 	});
 });

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -1588,13 +1588,13 @@ describe('Parsing', () => {
 					},
 					dataUrlencode: [String],
 				},
-				['-d', 'a=1', '--data-urlencode', 'b=2', '-d', 'c=3'],
+				['-d', 'a', '--data-urlencode', 'b', '-d', 'c'],
 			);
 
 			// `flags` groups by name, losing the interleaving...
 			expect(parsed.flags).toStrictEqual({
-				data: ['a=1', 'c=3'],
-				dataUrlencode: ['b=2'],
+				data: ['a', 'c'],
+				dataUrlencode: ['b'],
 			});
 
 			// ...but `entries` preserves the command-line order.
@@ -1602,17 +1602,17 @@ describe('Parsing', () => {
 				{
 					type: 'known-flag',
 					name: 'data',
-					value: 'a=1',
+					value: 'a',
 				},
 				{
 					type: 'known-flag',
 					name: 'dataUrlencode',
-					value: 'b=2',
+					value: 'b',
 				},
 				{
 					type: 'known-flag',
 					name: 'data',
-					value: 'c=3',
+					value: 'c',
 				},
 			]);
 		});

--- a/tests/specs/type-flag/types.ts
+++ b/tests/specs/type-flag/types.ts
@@ -7,6 +7,7 @@ import {
 	type TypeFlagOptions,
 	type IgnoreFunction,
 	type PositionalArguments,
+	type ConsumedArgvItem,
 } from '#type-flag';
 import { createPositionalArguments } from '#type-flag/internal';
 
@@ -130,6 +131,7 @@ describe('Types', () => {
 					[flag: string]: (string | boolean)[];
 				};
 				_: PositionalArguments;
+				consumed: ConsumedArgvItem[];
 			}>();
 
 			expectTypeOf(parsed._).toEqualTypeOf<PositionalArguments>();
@@ -270,6 +272,7 @@ describe('Types', () => {
 					[flagName: string]: (string | boolean)[];
 				};
 				_: PositionalArguments;
+				consumed: ConsumedArgvItem[];
 			}>();
 		});
 
@@ -282,6 +285,7 @@ describe('Types', () => {
 					[flagName: string]: (string | boolean)[];
 				};
 				_: PositionalArguments;
+				consumed: ConsumedArgvItem[];
 			}>();
 		});
 

--- a/tests/specs/type-flag/types.ts
+++ b/tests/specs/type-flag/types.ts
@@ -7,7 +7,7 @@ import {
 	type TypeFlagOptions,
 	type IgnoreFunction,
 	type PositionalArguments,
-	type ConsumedArgvItem,
+	type ParsedArgvEntry,
 } from '#type-flag';
 import { createPositionalArguments } from '#type-flag/internal';
 
@@ -131,7 +131,7 @@ describe('Types', () => {
 					[flag: string]: (string | boolean)[];
 				};
 				_: PositionalArguments;
-				consumed: ConsumedArgvItem[];
+				entries: ParsedArgvEntry[];
 			}>();
 
 			expectTypeOf(parsed._).toEqualTypeOf<PositionalArguments>();
@@ -272,7 +272,7 @@ describe('Types', () => {
 					[flagName: string]: (string | boolean)[];
 				};
 				_: PositionalArguments;
-				consumed: ConsumedArgvItem[];
+				entries: ParsedArgvEntry[];
 			}>();
 		});
 
@@ -285,7 +285,7 @@ describe('Types', () => {
 					[flagName: string]: (string | boolean)[];
 				};
 				_: PositionalArguments;
-				consumed: ConsumedArgvItem[];
+				entries: ParsedArgvEntry[];
 			}>();
 		});
 


### PR DESCRIPTION
## Problem

`flags` groups repeated values per flag name, which discards how occurrences of *different* flags interleaved on the command line. For order-sensitive CLIs this is lossy:

```ts
typeFlag(
    { data: { type: [String], alias: 'd' }, dataUrlencode: [String] },
    ['-d', 'a', '--data-urlencode', 'b', '-d', 'c'],
)
// flags: { data: ['a', 'c'], dataUrlencode: ['b'] }
```

`b` arrived between `a` and `c`, but the per-flag arrays can't express that. A curl clone needs the argv order to assemble the request body in sequence; today it can only emit values grouped by flag. Reconstructing the order from raw argv is impossible because that loses the parser's work (`--a=b` vs `--a b`, alias/kebab resolution, negation, type parsing).

## Changes

Add `parsed.entries`: the ordered stream of every interpreted argv element, preserving relative order across flags. `flags`, `unknownFlags`, and `_` are all derived from it.

```ts
parsed.entries
// [
//   { type: 'known-flag', name: 'data', value: 'a' },
//   { type: 'known-flag', name: 'dataUrlencode', value: 'b' },
//   { type: 'known-flag', name: 'data', value: 'c' }
// ]
```

Each entry is discriminated by `type`:

- `known-flag` — `name` is the **canonical schema key** (alias/kebab/camelCase all resolve to it); `value` is the parsed value for that single occurrence.
- `unknown-flag` — `name` is the raw argv name; `value` is the explicit value or `true`.
- `argument` — a positional value.

`entries` covers only what the parser interprets. Tokens after the `--` delimiter aren't parsed, so they're excluded from `entries` and remain available through `_['--']`.

It's always present (no opt-in) — a single output property that's trivially ignorable. Elements skipped by `ignore` are excluded from `entries` too.

New type `ParsedArgvEntry`, exported from the main entry and added to `TypeFlag`. Since cleye types `ParsedArgv` as `TypeFlag<…> & …`, this flows through to cleye automatically.
