### PR TITLE
refactor: rename `known-flag` entry type to `flag`

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,15 +400,15 @@ parsed.flags // { data: ['a', 'c'], dataUrlencode: ['b'] }
 
 parsed.entries
 // [
-//   { type: 'known-flag', name: 'data', value: 'a' },
-//   { type: 'known-flag', name: 'dataUrlencode', value: 'b' },
-//   { type: 'known-flag', name: 'data', value: 'c' }
+//   { type: 'flag', name: 'data', value: 'a' },
+//   { type: 'flag', name: 'dataUrlencode', value: 'b' },
+//   { type: 'flag', name: 'data', value: 'c' }
 // ]
 ```
 
 Each entry is discriminated by `type`:
 
-- `known-flag` — a flag defined in the schema. `name` is the **canonical schema key** (regardless of whether the alias, kebab-case, or camelCase form was used), and `value` is the parsed value for that single occurrence.
+- `flag` — a flag defined in the schema (it landed in `flags`). `name` is the **canonical schema key** (regardless of whether the alias, kebab-case, or camelCase form was used), and `value` is the parsed value for that single occurrence.
 - `unknown-flag` — a flag not in the schema. `name` is the raw argv name; `value` is the explicit value or `true`.
 - `argument` — a positional value.
 
@@ -629,7 +629,7 @@ Type:
 ```ts
 type Options = {
     ignore?: (
-        type: 'known-flag' | 'unknown-flag' | 'argument',
+        type: 'flag' | 'unknown-flag' | 'argument',
         flagOrArgv: string,
         value: string | undefined
     ) => boolean | void

--- a/skills/type-flag/SKILL.md
+++ b/skills/type-flag/SKILL.md
@@ -88,12 +88,12 @@ Ordered stream of every interpreted argv element, preserving relative order acro
 
 ```ts
 type ParsedArgvEntry =
-    | { type: 'known-flag'; name: string; value: unknown }          // name = canonical schema key (alias/kebab resolved)
+    | { type: 'flag'; name: string; value: unknown }          // name = canonical schema key (alias/kebab resolved)
     | { type: 'unknown-flag'; name: string; value: string | boolean } // name = raw argv name
     | { type: 'argument'; value: string }
 ```
 
-`-d a --data-urlencode b -d c` → three `known-flag` items in argv order, each `name` being the canonical schema key. Ignored elements (via `ignore`) are excluded. Tokens after `--` are not parsed, so they don't appear here (use `_['--']`).
+`-d a --data-urlencode b -d c` → three `flag` items in argv order, each `name` being the canonical schema key. Ignored elements (via `ignore`) are excluded. Tokens after `--` are not parsed, so they don't appear here (use `_['--']`).
 
 ## Flag forms
 
@@ -139,7 +139,7 @@ Skip parsing specific tokens (leave them in `argv`). Called for each token:
 
 ```ts
 ignore?: (
-    type: 'known-flag' | 'unknown-flag' | 'argument',
+    type: 'flag' | 'unknown-flag' | 'argument',
     flagOrArgv: string,
     value: string | undefined,
 ) => boolean | void

--- a/src/type-flag.ts
+++ b/src/type-flag.ts
@@ -4,7 +4,7 @@ import {
 	type TypeFlagOptions,
 	type Simplify,
 	type ParsedArgvEntry,
-	KNOWN_FLAG,
+	FLAG,
 	UNKNOWN_FLAG,
 	ARGUMENT,
 } from './types.ts';
@@ -76,7 +76,7 @@ export const typeFlag = <Schemas extends Flags>(
 		}
 
 		entries.push({
-			type: KNOWN_FLAG,
+			type: FLAG,
 			name: pendingName,
 			value: applyParser(pendingParser, value || '', pendingRawName),
 		});
@@ -106,7 +106,7 @@ export const typeFlag = <Schemas extends Flags>(
 
 			if (
 				ignore?.(
-					flagData || negatedBaseName ? KNOWN_FLAG : UNKNOWN_FLAG,
+					flagData || negatedBaseName ? FLAG : UNKNOWN_FLAG,
 					name,
 					explicitValue,
 				)
@@ -133,7 +133,7 @@ export const typeFlag = <Schemas extends Flags>(
 
 			if (negatedBaseName) {
 				entries.push({
-					type: KNOWN_FLAG,
+					type: FLAG,
 					name: negatedBaseName,
 					value: false,
 				});

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,8 +223,8 @@ export type TypeFlag<Schemas extends Flags = Flags> = {
 	entries: ParsedArgvEntry[];
 };
 
-/** Constant indicating a known flag token type. */
-export const KNOWN_FLAG = 'known-flag';
+/** Constant indicating a defined (schema) flag token type. */
+export const FLAG = 'flag';
 
 /** Constant indicating an unknown flag token type. */
 export const UNKNOWN_FLAG = 'unknown-flag';
@@ -238,7 +238,7 @@ export const ARGUMENT = 'argument';
  */
 export type ParsedArgvEntry =
 	| {
-		type: typeof KNOWN_FLAG;
+		type: typeof FLAG;
 
 		/**
 		 * Canonical schema key — always the name as declared in the schema
@@ -272,7 +272,7 @@ export type ParsedArgvEntry =
  *
  * @param type - The type of element being processed:
  *   - `'argument'`: A positional argument (non-flag value)
- *   - `'known-flag'`: A flag defined in the schema
+ *   - `'flag'`: A flag defined in the schema
  *   - `'unknown-flag'`: A flag not defined in the schema
  * @param argvElement - The raw argv string. For arguments, this is the value itself.
  *   For flags, this is the flag name (e.g., `'--verbose'` or `'-v'`).
@@ -301,7 +301,7 @@ export type ParsedArgvEntry =
  * ```
  */
 export type IgnoreFunction = (
-	type: typeof ARGUMENT | typeof KNOWN_FLAG | typeof UNKNOWN_FLAG,
+	type: typeof ARGUMENT | typeof FLAG | typeof UNKNOWN_FLAG,
 	argvElement: string,
 	flagValue?: string,
 ) => boolean | void;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import {
 	type Flags,
 	type FlagSchema,
 	type ParsedArgvEntry,
-	KNOWN_FLAG,
+	FLAG,
 	UNKNOWN_FLAG,
 } from './types.ts';
 import { isStandardSchema, schemaToParser } from './standard-schema.ts';
@@ -189,7 +189,7 @@ export const createRegistry = (
 };
 
 /**
- * Bucket the ordered `entries` stream by kind: known-flag values grouped by
+ * Bucket the ordered `entries` stream by kind: defined-flag values grouped by
  * canonical name (order preserved), unknown flags grouped by raw name, and
  * positional arguments. Post-`--` tokens are not in `entries`.
  */
@@ -201,7 +201,7 @@ const groupEntries = (
 	const positionals: string[] = [];
 
 	for (const entry of entries) {
-		if (entry.type === KNOWN_FLAG) {
+		if (entry.type === FLAG) {
 			let values = knownFlagValues.get(entry.name);
 			if (!values) {
 				values = [];

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -1164,7 +1164,7 @@ describe('Parsing', () => {
 				argv,
 				{
 					ignore: (type, flagName) => (
-						type === 'known-flag'
+						type === 'flag'
 							&& flagName === 'string'
 					),
 				},
@@ -1477,7 +1477,7 @@ describe('Parsing', () => {
 			expect(Object.keys(parsed.flags)).toStrictEqual(['verbose']);
 		});
 
-		test('ignore callback receives no- prefixed name as known-flag', () => {
+		test('ignore callback receives no- prefixed name as flag', () => {
 			const ignoredFlags: [string, string][] = [];
 			typeFlag(
 				{
@@ -1494,7 +1494,7 @@ describe('Parsing', () => {
 			);
 
 			expect(ignoredFlags).toStrictEqual([
-				['known-flag', 'no-verbose'],
+				['flag', 'no-verbose'],
 				['unknown-flag', 'no-unknown'],
 			]);
 		});
@@ -1600,17 +1600,17 @@ describe('Parsing', () => {
 			// ...but `entries` preserves the command-line order.
 			expect(parsed.entries).toStrictEqual([
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'data',
 					value: 'a',
 				},
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'dataUrlencode',
 					value: 'b',
 				},
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'data',
 					value: 'c',
 				},
@@ -1630,17 +1630,17 @@ describe('Parsing', () => {
 
 			expect(parsed.entries).toStrictEqual([
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'dataUrlencode',
 					value: 'a',
 				},
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'dataUrlencode',
 					value: 'b',
 				},
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'dataUrlencode',
 					value: 'c',
 				},
@@ -1658,17 +1658,17 @@ describe('Parsing', () => {
 
 			expect(parsed.entries).toStrictEqual([
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'port',
 					value: 3000,
 				},
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'verbose',
 					value: true,
 				},
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'port',
 					value: 3001,
 				},
@@ -1684,12 +1684,12 @@ describe('Parsing', () => {
 			expect(parsed.flags.name).toBe('b');
 			expect(parsed.entries).toStrictEqual([
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'name',
 					value: 'a',
 				},
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'name',
 					value: 'b',
 				},
@@ -1708,7 +1708,7 @@ describe('Parsing', () => {
 					value: 'file.txt',
 				},
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'verbose',
 					value: true,
 				},
@@ -1737,7 +1737,7 @@ describe('Parsing', () => {
 					value: 'a',
 				},
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'verbose',
 					value: true,
 				},
@@ -1757,12 +1757,12 @@ describe('Parsing', () => {
 			expect(parsed.flags.cache).toBe(false);
 			expect(parsed.entries).toStrictEqual([
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'cache',
 					value: true,
 				},
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'cache',
 					value: false,
 				},
@@ -1777,7 +1777,7 @@ describe('Parsing', () => {
 				},
 				['--string', 'a', '--verbose', '--string', 'b'],
 				{
-					ignore: (type, flagName) => type === 'known-flag' && flagName === 'string',
+					ignore: (type, flagName) => type === 'flag' && flagName === 'string',
 				},
 			);
 
@@ -1789,7 +1789,7 @@ describe('Parsing', () => {
 					value: 'a',
 				},
 				{
-					type: 'known-flag',
+					type: 'flag',
 					name: 'verbose',
 					value: true,
 				},

--- a/tests/specs/type-flag/types.ts
+++ b/tests/specs/type-flag/types.ts
@@ -329,18 +329,18 @@ describe('Types', () => {
 			ignoreFunction('argument', 'some/path');
 			ignoreFunction('argument', 'some/path', undefined);
 			ignoreFunction('argument', 'some/path', 'value');
-			ignoreFunction('known-flag', '--foo', 'bar');
+			ignoreFunction('flag', '--foo', 'bar');
 			ignoreFunction('unknown-flag', '--baz', undefined);
-			ignoreFunction('known-flag', '--foo');
+			ignoreFunction('flag', '--foo');
 
 			// @ts-expect-error 2nd param must be string
 			ignoreFunction('argument', 123);
 
 			// @ts-expect-error 2nd param must be string
-			ignoreFunction('known-flag', 123);
+			ignoreFunction('flag', 123);
 
 			// @ts-expect-error 3rd param must be string or undefined
-			ignoreFunction('known-flag', '--foo', 123);
+			ignoreFunction('flag', '--foo', 123);
 
 			// @ts-expect-error 'type' must be one of the three constants
 			ignoreFunction('other-type', 'foo');
@@ -349,11 +349,11 @@ describe('Types', () => {
 		test('Implementation with explicit types', () => {
 			const options: TypeFlagOptions = {
 				ignore: (
-					type: 'argument' | 'known-flag' | 'unknown-flag',
+					type: 'argument' | 'flag' | 'unknown-flag',
 					argvElement: string,
 					flagValue?: string,
 				) => {
-					expectTypeOf(type).toEqualTypeOf<'argument' | 'known-flag' | 'unknown-flag'>();
+					expectTypeOf(type).toEqualTypeOf<'argument' | 'flag' | 'unknown-flag'>();
 					expectTypeOf(argvElement).toEqualTypeOf<string>();
 					expectTypeOf(flagValue).toEqualTypeOf<string | undefined>();
 					return false;
@@ -384,7 +384,7 @@ describe('Types', () => {
 		test('3-parameter callback works', () => {
 			const options: TypeFlagOptions = {
 				ignore(type, argvElement, flagValue) {
-					expectTypeOf(type).toEqualTypeOf<'argument' | 'known-flag' | 'unknown-flag'>();
+					expectTypeOf(type).toEqualTypeOf<'argument' | 'flag' | 'unknown-flag'>();
 					expectTypeOf(argvElement).toEqualTypeOf<string>();
 					expectTypeOf(flagValue).toEqualTypeOf<string | undefined>();
 					return false;


### PR DESCRIPTION
## Problem

The `entries` stream tagged schema-defined flags as `type: 'known-flag'` — parser-internal wording that doesn't match the public vocabulary. The result object already exposes `flags` (defined), `unknownFlags`, and `_`, so `'known-flag'` was an inconsistent third term for the thing that lands in `flags`.

## Changes

Rename the entry type `'known-flag'` → `'flag'` so the discriminant mirrors the top-level buckets:

```ts
type ParsedArgvEntry =
    | { type: 'flag'; name: string; value: unknown }
    | { type: 'unknown-flag'; name: string; value: string | boolean }
    | { type: 'argument'; value: string }
```

For consistency, this also applies to the `ignore` callback's `type` argument, which now accepts `'flag' | 'unknown-flag' | 'argument'`. Both surfaces shared the same internal constant, so they move together — avoiding two public vocabularies for the same concept.

`'unknown-flag'` and `'argument'` are unchanged. Internal constant `KNOWN_FLAG` → `FLAG`. Docs (README, skill) and tests updated.

BREAKING CHANGE: The `'known-flag'` token type is renamed to `'flag'`. Code that checks `entry.type === 'known-flag'` on `parsed.entries`, or compares the `ignore` callback's `type` against `'known-flag'`, must use `'flag'` instead.
