### PR TITLE
fix: return null-prototype `flags` and `unknownFlags` objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,8 @@ type Parsed = {
 
 See [Ordered Entries](#ordered-entries) for the `ParsedArgvEntry` shape.
 
+`flags` and `unknownFlags` are null-prototype objects (`Object.create(null)`), so a flag named `__proto__` is a normal key and the result can't be prototype-polluted. Read them as plain dictionaries (`name in flags`, `Object.hasOwn(flags, name)`) rather than via inherited methods like `flags.hasOwnProperty(name)`.
+
 #### flagSchema
 
 Type:

--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ type Parsed = {
 
 See [Ordered Entries](#ordered-entries) for the `ParsedArgvEntry` shape.
 
-`flags` and `unknownFlags` are null-prototype objects, so a flag named `__proto__` is a normal key and the result can't be prototype-polluted. Read them with `name in flags` or `Object.hasOwn(flags, name)`.
+`flags` and `unknownFlags` are null-prototype objects. Read them with `name in flags` or `Object.hasOwn(flags, name)`.
 
 #### flagSchema
 

--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ type Parsed = {
 
 See [Ordered Entries](#ordered-entries) for the `ParsedArgvEntry` shape.
 
-`flags` and `unknownFlags` are null-prototype objects, so a flag named `__proto__` is a normal key and the result can't be prototype-polluted. Read them as plain dictionaries with `name in flags` or `Object.hasOwn(flags, name)`.
+`flags` and `unknownFlags` are null-prototype objects, so a flag named `__proto__` is a normal key and the result can't be prototype-polluted. Read them with `name in flags` or `Object.hasOwn(flags, name)`.
 
 #### flagSchema
 

--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ type Parsed = {
 
 See [Ordered Entries](#ordered-entries) for the `ParsedArgvEntry` shape.
 
-`flags` and `unknownFlags` are null-prototype objects (`Object.create(null)`), so a flag named `__proto__` is a normal key and the result can't be prototype-polluted. Read them as plain dictionaries (`name in flags`, `Object.hasOwn(flags, name)`) rather than via inherited methods like `flags.hasOwnProperty(name)`.
+`flags` and `unknownFlags` are null-prototype objects, so a flag named `__proto__` is a normal key and the result can't be prototype-polluted. Read them as plain dictionaries with `name in flags` or `Object.hasOwn(flags, name)`.
 
 #### flagSchema
 

--- a/skills/type-flag/SKILL.md
+++ b/skills/type-flag/SKILL.md
@@ -82,7 +82,7 @@ typeFlag({
 }
 ```
 
-`flags` and `unknownFlags` are `Object.create(null)` dictionaries (so `--__proto__` is a safe own key, no prototype pollution). Use `name in flags` / `Object.hasOwn`, not `flags.hasOwnProperty`.
+`flags` and `unknownFlags` are null-prototype dictionaries, so `--__proto__` is a safe own key with no prototype pollution. Use `name in flags` or `Object.hasOwn(flags, name)`.
 
 ### `entries` (advanced)
 

--- a/skills/type-flag/SKILL.md
+++ b/skills/type-flag/SKILL.md
@@ -75,12 +75,14 @@ typeFlag({
 
 ```ts
 {
-    flags:        { [name]: InferredType },
-    unknownFlags: { [name]: (string | boolean)[] },  // not camelCased
+    flags:        { [name]: InferredType },          // null-prototype object
+    unknownFlags: { [name]: (string | boolean)[] },  // null-prototype object; not camelCased
     _:            string[] & { '--': string[] },      // positional; everything after `--` also in `_['--']`
     entries:      ParsedArgvEntry[],                  // advanced; see below
 }
 ```
+
+`flags` and `unknownFlags` are `Object.create(null)` dictionaries (so `--__proto__` is a safe own key, no prototype pollution). Use `name in flags` / `Object.hasOwn`, not `flags.hasOwnProperty`.
 
 ### `entries` (advanced)
 

--- a/skills/type-flag/SKILL.md
+++ b/skills/type-flag/SKILL.md
@@ -82,7 +82,7 @@ typeFlag({
 }
 ```
 
-`flags` and `unknownFlags` are null-prototype objects, so `--__proto__` is a safe own key with no prototype pollution. Use `name in flags` or `Object.hasOwn(flags, name)`.
+`flags` and `unknownFlags` are null-prototype objects. Use `name in flags` or `Object.hasOwn(flags, name)`.
 
 ### `entries` (advanced)
 

--- a/skills/type-flag/SKILL.md
+++ b/skills/type-flag/SKILL.md
@@ -82,7 +82,7 @@ typeFlag({
 }
 ```
 
-`flags` and `unknownFlags` are null-prototype dictionaries, so `--__proto__` is a safe own key with no prototype pollution. Use `name in flags` or `Object.hasOwn(flags, name)`.
+`flags` and `unknownFlags` are null-prototype objects, so `--__proto__` is a safe own key with no prototype pollution. Use `name in flags` or `Object.hasOwn(flags, name)`.
 
 ### `entries` (advanced)
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -209,10 +209,23 @@ const groupEntries = (
 			}
 			values.push(entry.value);
 		} else if (entry.type === UNKNOWN_FLAG) {
-			if (!hasOwn(unknownFlags, entry.name)) {
-				unknownFlags[entry.name] = [];
+			let values = hasOwn(unknownFlags, entry.name)
+				? unknownFlags[entry.name]
+				: undefined;
+			if (!values) {
+				values = [];
+				// `defineProperty` (not assignment) so a flag literally named
+				// `__proto__` becomes an own data property instead of invoking the
+				// `__proto__` setter — which would mutate the result's prototype and
+				// silently drop the flag.
+				Object.defineProperty(unknownFlags, entry.name, {
+					value: values,
+					writable: true,
+					enumerable: true,
+					configurable: true,
+				});
 			}
-			unknownFlags[entry.name].push(entry.value);
+			values.push(entry.value);
 		} else {
 			positionals.push(entry.value);
 		}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -197,7 +197,10 @@ const groupEntries = (
 	entries: ParsedArgvEntry[],
 ) => {
 	const knownFlagValues = new Map<string, unknown[]>();
-	const unknownFlags: Record<string, (string | boolean)[]> = {};
+	// Null-prototype: this is a dictionary keyed by raw argv names, so a flag
+	// literally named `__proto__` must become an own key rather than hit the
+	// `Object.prototype` `__proto__` setter (which would pollute the result).
+	const unknownFlags: Record<string, (string | boolean)[]> = Object.create(null);
 	const positionals: string[] = [];
 
 	for (const entry of entries) {
@@ -209,23 +212,10 @@ const groupEntries = (
 			}
 			values.push(entry.value);
 		} else if (entry.type === UNKNOWN_FLAG) {
-			let values = hasOwn(unknownFlags, entry.name)
-				? unknownFlags[entry.name]
-				: undefined;
-			if (!values) {
-				values = [];
-				// `defineProperty` (not assignment) so a flag literally named
-				// `__proto__` becomes an own data property instead of invoking the
-				// `__proto__` setter — which would mutate the result's prototype and
-				// silently drop the flag.
-				Object.defineProperty(unknownFlags, entry.name, {
-					value: values,
-					writable: true,
-					enumerable: true,
-					configurable: true,
-				});
+			if (!hasOwn(unknownFlags, entry.name)) {
+				unknownFlags[entry.name] = [];
 			}
-			values.push(entry.value);
+			unknownFlags[entry.name].push(entry.value);
 		} else {
 			positionals.push(entry.value);
 		}
@@ -283,7 +273,10 @@ export const finalizeParsed = (
 		positionals,
 	} = groupEntries(entries);
 
-	const flags: Record<string, unknown> = {};
+	// Null-prototype for consistency with `unknownFlags` and to keep the result
+	// a clean dictionary (a computed `{ ['__proto__']: ... }` schema key can't
+	// reach `Object.prototype`'s setter here).
+	const flags: Record<string, unknown> = Object.create(null);
 	for (const flagName in schemas) {
 		if (!hasOwn(schemas, flagName)) {
 			continue;

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -12,6 +12,31 @@ describe('Parsing', () => {
 			});
 		});
 
+		test('unknown __proto__ flag does not pollute the prototype', () => {
+			const parsed = typeFlag({}, ['--__proto__', '--__proto__=x']);
+
+			// The result's prototype must be untouched.
+			expect(Object.getPrototypeOf(parsed.unknownFlags)).toBe(Object.prototype);
+
+			// `__proto__` is captured as an own data property, not via the setter.
+			expect(Object.hasOwn(parsed.unknownFlags, '__proto__')).toBe(true);
+			const descriptor = Object.getOwnPropertyDescriptor(parsed.unknownFlags, '__proto__');
+			expect<unknown>(descriptor?.value).toStrictEqual([true, 'x']);
+
+			expect(parsed.entries).toStrictEqual([
+				{
+					type: 'unknown-flag',
+					name: '__proto__',
+					value: true,
+				},
+				{
+					type: 'unknown-flag',
+					name: '__proto__',
+					value: 'x',
+				},
+			]);
+		});
+
 		test('string to boolean', () => {
 			const parsed = typeFlag({
 				boolean: Boolean,

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -2,14 +2,22 @@ import { describe, test, expect } from 'manten';
 import { typeFlag } from '#type-flag';
 import { createPositionalArguments } from '#type-flag/internal';
 
+// `flags` and `unknownFlags` are returned as null-prototype objects, so
+// strict-equality expectations must match that prototype too.
+const nullPrototypeObject = <T extends object>(object: T): T => (
+	Object.assign(Object.create(null), object)
+);
+
 describe('Parsing', () => {
 	describe('edge-cases', () => {
 		test('Object prototype property', () => {
 			const parsed = typeFlag({}, ['--to-string']);
-			expect<Record<PropertyKey, never>>({ ...parsed.flags }).toStrictEqual({});
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
+			expect<Record<PropertyKey, never>>(parsed.flags).toStrictEqual(nullPrototypeObject({}));
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({
 				'to-string': [true],
-			});
+			}));
 		});
 
 		test('flags and unknownFlags are null-prototype objects', () => {
@@ -21,7 +29,7 @@ describe('Parsing', () => {
 		test('unknown __proto__ flag does not pollute the prototype', () => {
 			const parsed = typeFlag({}, ['--__proto__', '--__proto__=x']);
 
-			// Null-prototype dictionary, so `__proto__` is a normal own key
+			// Null-prototype object, so `__proto__` is a normal own key
 			// rather than a trip through the `Object.prototype` setter.
 			expect(Object.getPrototypeOf(parsed.unknownFlags)).toBe(null);
 			expect(Object.hasOwn(parsed.unknownFlags, '__proto__')).toBe(true);
@@ -47,9 +55,9 @@ describe('Parsing', () => {
 				boolean: Boolean,
 			}, ['--boolean=value']);
 
-			expect<{ boolean?: boolean }>({ ...parsed.flags }).toStrictEqual({
+			expect<{ boolean?: boolean }>(parsed.flags).toStrictEqual(nullPrototypeObject({
 				boolean: true,
-			});
+			}));
 		});
 
 		test('end of flags', () => {
@@ -57,9 +65,9 @@ describe('Parsing', () => {
 				string: String,
 			}, ['--string', '--', 'value']);
 
-			expect<{ string?: string }>({ ...parsed.flags }).toStrictEqual({
+			expect<{ string?: string }>(parsed.flags).toStrictEqual(nullPrototypeObject({
 				string: '',
-			});
+			}));
 
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(
 				Object.assign(
@@ -74,9 +82,9 @@ describe('Parsing', () => {
 				_flag: Boolean,
 			}, ['--_flag']);
 
-			expect<{ _flag?: boolean }>({ ...parsed.flags }).toStrictEqual({
+			expect<{ _flag?: boolean }>(parsed.flags).toStrictEqual(nullPrototypeObject({
 				_flag: true,
-			});
+			}));
 		});
 
 		test('Negative number as argument', () => {
@@ -84,14 +92,16 @@ describe('Parsing', () => {
 				number: Number,
 			}, ['-123']);
 
-			expect<{ number?: number }>({ ...parsed.flags }).toStrictEqual({
+			expect<{ number?: number }>(parsed.flags).toStrictEqual(nullPrototypeObject({
 				number: undefined,
-			});
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
+			}));
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({
 				1: [true],
 				2: [true],
 				3: [true],
-			});
+			}));
 		});
 
 		test('Negative number with flag', () => {
@@ -101,10 +111,12 @@ describe('Parsing', () => {
 			}, argv);
 
 			// -123 is consumed as the value for --number
-			expect<{ number?: number }>({ ...parsed.flags }).toStrictEqual({
+			expect<{ number?: number }>(parsed.flags).toStrictEqual(nullPrototypeObject({
 				number: -123,
-			});
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({});
+			}));
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({}));
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(
 				Object.assign(
 					[],
@@ -119,9 +131,9 @@ describe('Parsing', () => {
 				number: Number,
 			}, ['--number=-123']);
 
-			expect<{ number?: number }>({ ...parsed.flags }).toStrictEqual({
+			expect<{ number?: number }>(parsed.flags).toStrictEqual(nullPrototypeObject({
 				number: -123,
-			});
+			}));
 		});
 
 		test('invalid consolidated aliases', () => {
@@ -130,8 +142,10 @@ describe('Parsing', () => {
 			);
 
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(Object.assign([], { '--': [] }));
-			expect<Record<PropertyKey, never>>({ ...parsed.flags }).toStrictEqual({});
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
+			expect<Record<PropertyKey, never>>(parsed.flags).toStrictEqual(nullPrototypeObject({}));
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({
 				i: [true, true, true],
 				n: [true],
 				v: [true],
@@ -140,7 +154,7 @@ describe('Parsing', () => {
 				d: [true],
 				A: [true],
 				s: [true],
-			});
+			}));
 		});
 
 		test('Frozen argv array', () => {
@@ -159,13 +173,15 @@ describe('Parsing', () => {
 		test('Unknown flags starting with numbers', () => {
 			const parsed = typeFlag({}, ['--123abc', '--456', '-7', '-8a']);
 
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({
 				'123abc': [true],
 				456: [true],
 				7: [true],
 				8: [true],
 				a: [true],
-			});
+			}));
 		});
 	});
 
@@ -174,21 +190,27 @@ describe('Parsing', () => {
 			const argv = ['--retry', '-5'];
 			const parsed = typeFlag({ retry: Number }, argv);
 
-			expect<{ retry?: number }>({ ...parsed.flags }).toStrictEqual({ retry: -5 });
-			expect({ ...parsed.unknownFlags }).toStrictEqual({});
+			expect<{ retry?: number }>(
+				parsed.flags,
+			).toStrictEqual(nullPrototypeObject({ retry: -5 }));
+			expect(parsed.unknownFlags).toStrictEqual(nullPrototypeObject({}));
 			expect<string[]>(argv).toStrictEqual([]);
 		});
 
 		test('consumes negative decimal', () => {
 			const parsed = typeFlag({ retry: Number }, ['--retry', '-5.5']);
 
-			expect<{ retry?: number }>({ ...parsed.flags }).toStrictEqual({ retry: -5.5 });
+			expect<{ retry?: number }>(
+				parsed.flags,
+			).toStrictEqual(nullPrototypeObject({ retry: -5.5 }));
 		});
 
 		test('consumes negative scientific notation', () => {
 			const parsed = typeFlag({ retry: Number }, ['--retry', '-5e3']);
 
-			expect<{ retry?: number }>({ ...parsed.flags }).toStrictEqual({ retry: -5000 });
+			expect<{ retry?: number }>(
+				parsed.flags,
+			).toStrictEqual(nullPrototypeObject({ retry: -5000 }));
 		});
 
 		test('consumes negative via alias', () => {
@@ -199,25 +221,33 @@ describe('Parsing', () => {
 				},
 			}, ['-r', '-5']);
 
-			expect<{ retry?: number }>({ ...parsed.flags }).toStrictEqual({ retry: -5 });
+			expect<{ retry?: number }>(
+				parsed.flags,
+			).toStrictEqual(nullPrototypeObject({ retry: -5 }));
 		});
 
 		test('explicit = value still works', () => {
 			const parsed = typeFlag({ retry: Number }, ['--retry=-5']);
 
-			expect<{ retry?: number }>({ ...parsed.flags }).toStrictEqual({ retry: -5 });
+			expect<{ retry?: number }>(
+				parsed.flags,
+			).toStrictEqual(nullPrototypeObject({ retry: -5 }));
 		});
 
 		test('string flag consumes negative-number token', () => {
 			const parsed = typeFlag({ name: String }, ['--name', '-5']);
 
-			expect<{ name?: string }>({ ...parsed.flags }).toStrictEqual({ name: '-5' });
+			expect<{ name?: string }>(
+				parsed.flags,
+			).toStrictEqual(nullPrototypeObject({ name: '-5' }));
 		});
 
 		test('array of numbers consumes negatives', () => {
 			const parsed = typeFlag({ nums: [Number] }, ['--nums', '-1', '--nums', '-2']);
 
-			expect<{ nums: number[] }>({ ...parsed.flags }).toStrictEqual({ nums: [-1, -2] });
+			expect<{ nums: number[] }>(
+				parsed.flags,
+			).toStrictEqual(nullPrototypeObject({ nums: [-1, -2] }));
 		});
 
 		describe('defined flags take precedence', () => {
@@ -234,12 +264,12 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-5']);
 
-				expect({ ...parsed.flags }).toStrictEqual({
+				expect(parsed.flags).toStrictEqual(nullPrototypeObject({
 					retry: Number.NaN,
 					fast: true,
 					name: undefined,
-				});
-				expect({ ...parsed.unknownFlags }).toStrictEqual({});
+				}));
+				expect(parsed.unknownFlags).toStrictEqual(nullPrototypeObject({}));
 			});
 
 			test('-5 then -n value', () => {
@@ -255,11 +285,11 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-5', '-n', 'Hiroki']);
 
-				expect({ ...parsed.flags }).toStrictEqual({
+				expect(parsed.flags).toStrictEqual(nullPrototypeObject({
 					retry: Number.NaN,
 					fast: true,
 					name: 'Hiroki',
-				});
+				}));
 			});
 
 			test('alias group -5n', () => {
@@ -275,11 +305,11 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-5n', 'Hiroki']);
 
-				expect({ ...parsed.flags }).toStrictEqual({
+				expect(parsed.flags).toStrictEqual(nullPrototypeObject({
 					retry: Number.NaN,
 					fast: true,
 					name: 'Hiroki',
-				});
+				}));
 			});
 
 			test('partial match -50 is a number', () => {
@@ -295,11 +325,11 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-50']);
 
-				expect({ ...parsed.flags }).toStrictEqual({
+				expect(parsed.flags).toStrictEqual(nullPrototypeObject({
 					retry: -50,
 					fast: undefined,
 					name: undefined,
-				});
+				}));
 			});
 
 			test('decimal -5.5 is a number even when 5 is a flag', () => {
@@ -315,11 +345,11 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-5.5']);
 
-				expect({ ...parsed.flags }).toStrictEqual({
+				expect(parsed.flags).toStrictEqual(nullPrototypeObject({
 					retry: -5.5,
 					fast: undefined,
 					name: undefined,
-				});
+				}));
 			});
 
 			test('all-digit alias group -512', () => {
@@ -339,12 +369,12 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-512']);
 
-				expect({ ...parsed.flags }).toStrictEqual({
+				expect(parsed.flags).toStrictEqual(nullPrototypeObject({
 					retry: Number.NaN,
 					alpha: true,
 					beta: true,
 					gamma: true,
-				});
+				}));
 			});
 		});
 
@@ -358,10 +388,10 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-5']);
 
-				expect({ ...parsed.flags }).toStrictEqual({
+				expect(parsed.flags).toStrictEqual(nullPrototypeObject({
 					retry: -5,
 					one: undefined,
-				});
+				}));
 			});
 
 			test('registered -1 standalone is the flag', () => {
@@ -373,10 +403,10 @@ describe('Parsing', () => {
 					},
 				}, ['-1']);
 
-				expect({ ...parsed.flags }).toStrictEqual({
+				expect(parsed.flags).toStrictEqual(nullPrototypeObject({
 					retry: undefined,
 					one: true,
-				});
+				}));
 			});
 
 			test('value and flag in one command', () => {
@@ -388,10 +418,10 @@ describe('Parsing', () => {
 					},
 				}, ['-1', '--retry', '-5']);
 
-				expect({ ...parsed.flags }).toStrictEqual({
+				expect(parsed.flags).toStrictEqual(nullPrototypeObject({
 					retry: -5,
 					one: true,
-				});
+				}));
 			});
 
 			test('registered -1 wins after a value flag', () => {
@@ -403,10 +433,10 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-1']);
 
-				expect({ ...parsed.flags }).toStrictEqual({
+				expect(parsed.flags).toStrictEqual(nullPrototypeObject({
 					retry: Number.NaN,
 					one: true,
-				});
+				}));
 			});
 		});
 
@@ -414,22 +444,22 @@ describe('Parsing', () => {
 			test('standalone negative is an unknown flag', () => {
 				const parsed = typeFlag({ retry: Number }, ['-7']);
 
-				expect({ ...parsed.flags }).toStrictEqual({ retry: undefined });
-				expect({ ...parsed.unknownFlags }).toStrictEqual({ 7: [true] });
+				expect(parsed.flags).toStrictEqual(nullPrototypeObject({ retry: undefined }));
+				expect(parsed.unknownFlags).toStrictEqual(nullPrototypeObject({ 7: [true] }));
 			});
 
 			test('boolean flag does not consume a following negative', () => {
 				const parsed = typeFlag({ verbose: Boolean }, ['--verbose', '-5']);
 
-				expect({ ...parsed.flags }).toStrictEqual({ verbose: true });
-				expect({ ...parsed.unknownFlags }).toStrictEqual({ 5: [true] });
+				expect(parsed.flags).toStrictEqual(nullPrototypeObject({ verbose: true }));
+				expect(parsed.unknownFlags).toStrictEqual(nullPrototypeObject({ 5: [true] }));
 			});
 
 			test('array consumes one value; trailing negative is an unknown flag', () => {
 				const parsed = typeFlag({ nums: [Number] }, ['--nums', '-1', '-2']);
 
-				expect({ ...parsed.flags }).toStrictEqual({ nums: [-1] });
-				expect({ ...parsed.unknownFlags }).toStrictEqual({ 2: [true] });
+				expect(parsed.flags).toStrictEqual(nullPrototypeObject({ nums: [-1] }));
+				expect(parsed.unknownFlags).toStrictEqual(nullPrototypeObject({ 2: [true] }));
 			});
 		});
 
@@ -437,7 +467,9 @@ describe('Parsing', () => {
 			const argv = ['--retry', '--', '-5'];
 			const parsed = typeFlag({ retry: Number }, argv);
 
-			expect<{ retry?: number }>({ ...parsed.flags }).toStrictEqual({ retry: Number.NaN });
+			expect<{ retry?: number }>(
+				parsed.flags,
+			).toStrictEqual(nullPrototypeObject({ retry: Number.NaN }));
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(
 				Object.assign(['-5'], { '--': ['-5'] }),
 			);
@@ -903,7 +935,9 @@ describe('Parsing', () => {
 			}, ['-ab']);
 			expect<boolean | undefined>(parsed.flags.a).toBe(true);
 			expect<boolean | undefined>(parsed.flags.b).toBe(true);
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({});
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({}));
 		});
 
 		test('groups three single-char boolean names', () => {
@@ -915,7 +949,9 @@ describe('Parsing', () => {
 			expect<boolean | undefined>(parsed.flags.a).toBe(true);
 			expect<boolean | undefined>(parsed.flags.b).toBe(true);
 			expect<boolean | undefined>(parsed.flags.c).toBe(true);
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({});
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({}));
 		});
 
 		test('last char in group takes next-arg value', () => {
@@ -939,9 +975,11 @@ describe('Parsing', () => {
 		test('unknown char in group goes to unknownFlags, known chars still set', () => {
 			const parsed = typeFlag({ a: Boolean }, ['-ab']);
 			expect<boolean | undefined>(parsed.flags.a).toBe(true);
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({
 				b: [true],
-			});
+			}));
 		});
 
 		test('group mixes single-char name, alias, and value-taking flag', () => {
@@ -1128,9 +1166,11 @@ describe('Parsing', () => {
 
 			expect<boolean | undefined>(parsed.flags.alpha).toBe(true);
 			expect<boolean | undefined>(parsed.flags.gamma).toBe(true);
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({
 				x: [true],
-			});
+			}));
 			expect<string[]>(argv).toStrictEqual([]);
 		});
 	});
@@ -1159,13 +1199,13 @@ describe('Parsing', () => {
 
 		expect<{
 			[flag: string]: never;
-		}>({ ...parsed.flags }).toStrictEqual({});
+		}>(parsed.flags).toStrictEqual(nullPrototypeObject({}));
 
 		type UnknownFlags = {
 			[flag: string]: (boolean | string)[];
 		};
 
-		expect<UnknownFlags>({ ...parsed.unknownFlags }).toStrictEqual({
+		expect<UnknownFlags>(parsed.unknownFlags).toStrictEqual(nullPrototypeObject({
 			unknownFlag: [true, 'false', ''],
 			u: [true, 'value'],
 			3: [true],
@@ -1174,7 +1214,7 @@ describe('Parsing', () => {
 			f: [true, true, 'a'],
 			'kebab-case': [true],
 			toString: [true],
-		});
+		}));
 		expect<string[]>(parsed._).toStrictEqual(
 			Object.assign(
 				['arg1', 'arg2', 'arg3', 'arg4'],
@@ -1200,14 +1240,16 @@ describe('Parsing', () => {
 				},
 			);
 
-			expect<{ string: string[] }>({ ...parsed.flags }).toStrictEqual({
+			expect<{ string: string[] }>(parsed.flags).toStrictEqual(nullPrototypeObject({
 				string: [],
-			});
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
+			}));
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({
 				unknown: [true, 'd'],
 				u: [true],
 				v: [true, true, '1'],
-			});
+			}));
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(Object.assign(
 				['a', 'c'],
 				{ '--': [] },
@@ -1235,11 +1277,13 @@ describe('Parsing', () => {
 			);
 
 			expect<{ string: string[];
-				boolean: boolean | undefined; }>({ ...parsed.flags }).toStrictEqual({
+				boolean: boolean | undefined; }>(parsed.flags).toStrictEqual(nullPrototypeObject({
 				string: ['a', 'b', 'd'],
 				boolean: true,
-			});
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({});
+			}));
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({}));
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(Object.assign(
 				['c'],
 				{ '--': [] },
@@ -1271,10 +1315,12 @@ describe('Parsing', () => {
 				},
 			);
 
-			expect<{ string: string[] }>({ ...parsed.flags }).toStrictEqual({
+			expect<{ string: string[] }>(parsed.flags).toStrictEqual(nullPrototypeObject({
 				string: ['value'],
-			});
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({});
+			}));
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({}));
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(Object.assign(
 				[],
 				{ '--': [] },
@@ -1302,11 +1348,13 @@ describe('Parsing', () => {
 			);
 
 			expect<{ string: string | undefined;
-				boolean: boolean | undefined; }>({ ...parsed.flags }).toStrictEqual({
+				boolean: boolean | undefined; }>(parsed.flags).toStrictEqual(nullPrototypeObject({
 				string: 'hello',
 				boolean: undefined,
-			});
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({});
+			}));
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({}));
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(Object.assign(
 				['a'],
 				{ '--': [] },
@@ -1343,7 +1391,9 @@ describe('Parsing', () => {
 			);
 
 			expect<string | undefined>(parsed.flags.string).toBe(undefined);
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({});
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({}));
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(
 				Object.assign(
 					[],
@@ -1456,9 +1506,11 @@ describe('Parsing', () => {
 
 			expect<boolean | undefined>(parsed.flags.verbose).toBe(false);
 			expect<number | undefined>(parsed.flags.count).toBe(undefined);
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({
 				'no-count': [true],
-			});
+			}));
 		});
 
 		test('kebab-case negation', () => {
@@ -1553,9 +1605,11 @@ describe('Parsing', () => {
 			}, ['--no-verbose']);
 
 			expect<boolean | undefined>(parsed.flags.verbose).toBe(undefined);
-			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
+			expect<Record<string, (string | boolean)[]>>(
+				parsed.unknownFlags,
+			).toStrictEqual(nullPrototypeObject({
 				'no-verbose': [true],
-			});
+			}));
 		});
 	});
 
@@ -1622,10 +1676,10 @@ describe('Parsing', () => {
 			);
 
 			// `flags` groups by name, losing the interleaving...
-			expect({ ...parsed.flags }).toStrictEqual({
+			expect(parsed.flags).toStrictEqual(nullPrototypeObject({
 				data: ['a', 'c'],
 				dataUrlencode: ['b'],
-			});
+			}));
 
 			// ...but `entries` preserves the command-line order.
 			expect(parsed.entries).toStrictEqual([

--- a/tests/specs/type-flag/parsing.ts
+++ b/tests/specs/type-flag/parsing.ts
@@ -6,19 +6,24 @@ describe('Parsing', () => {
 	describe('edge-cases', () => {
 		test('Object prototype property', () => {
 			const parsed = typeFlag({}, ['--to-string']);
-			expect<Record<PropertyKey, never>>(parsed.flags).toStrictEqual({});
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({
+			expect<Record<PropertyKey, never>>({ ...parsed.flags }).toStrictEqual({});
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
 				'to-string': [true],
 			});
+		});
+
+		test('flags and unknownFlags are null-prototype objects', () => {
+			const parsed = typeFlag({ known: String }, ['--known', 'a', '--other']);
+			expect(Object.getPrototypeOf(parsed.flags)).toBe(null);
+			expect(Object.getPrototypeOf(parsed.unknownFlags)).toBe(null);
 		});
 
 		test('unknown __proto__ flag does not pollute the prototype', () => {
 			const parsed = typeFlag({}, ['--__proto__', '--__proto__=x']);
 
-			// The result's prototype must be untouched.
-			expect(Object.getPrototypeOf(parsed.unknownFlags)).toBe(Object.prototype);
-
-			// `__proto__` is captured as an own data property, not via the setter.
+			// Null-prototype dictionary, so `__proto__` is a normal own key
+			// rather than a trip through the `Object.prototype` setter.
+			expect(Object.getPrototypeOf(parsed.unknownFlags)).toBe(null);
 			expect(Object.hasOwn(parsed.unknownFlags, '__proto__')).toBe(true);
 			const descriptor = Object.getOwnPropertyDescriptor(parsed.unknownFlags, '__proto__');
 			expect<unknown>(descriptor?.value).toStrictEqual([true, 'x']);
@@ -42,7 +47,7 @@ describe('Parsing', () => {
 				boolean: Boolean,
 			}, ['--boolean=value']);
 
-			expect<{ boolean?: boolean }>(parsed.flags).toStrictEqual({
+			expect<{ boolean?: boolean }>({ ...parsed.flags }).toStrictEqual({
 				boolean: true,
 			});
 		});
@@ -52,7 +57,7 @@ describe('Parsing', () => {
 				string: String,
 			}, ['--string', '--', 'value']);
 
-			expect<{ string?: string }>(parsed.flags).toStrictEqual({
+			expect<{ string?: string }>({ ...parsed.flags }).toStrictEqual({
 				string: '',
 			});
 
@@ -69,7 +74,7 @@ describe('Parsing', () => {
 				_flag: Boolean,
 			}, ['--_flag']);
 
-			expect<{ _flag?: boolean }>(parsed.flags).toStrictEqual({
+			expect<{ _flag?: boolean }>({ ...parsed.flags }).toStrictEqual({
 				_flag: true,
 			});
 		});
@@ -79,10 +84,10 @@ describe('Parsing', () => {
 				number: Number,
 			}, ['-123']);
 
-			expect<{ number?: number }>(parsed.flags).toStrictEqual({
+			expect<{ number?: number }>({ ...parsed.flags }).toStrictEqual({
 				number: undefined,
 			});
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
 				1: [true],
 				2: [true],
 				3: [true],
@@ -96,10 +101,10 @@ describe('Parsing', () => {
 			}, argv);
 
 			// -123 is consumed as the value for --number
-			expect<{ number?: number }>(parsed.flags).toStrictEqual({
+			expect<{ number?: number }>({ ...parsed.flags }).toStrictEqual({
 				number: -123,
 			});
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({});
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({});
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(
 				Object.assign(
 					[],
@@ -114,7 +119,7 @@ describe('Parsing', () => {
 				number: Number,
 			}, ['--number=-123']);
 
-			expect<{ number?: number }>(parsed.flags).toStrictEqual({
+			expect<{ number?: number }>({ ...parsed.flags }).toStrictEqual({
 				number: -123,
 			});
 		});
@@ -125,8 +130,8 @@ describe('Parsing', () => {
 			);
 
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(Object.assign([], { '--': [] }));
-			expect<Record<PropertyKey, never>>(parsed.flags).toStrictEqual({});
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({
+			expect<Record<PropertyKey, never>>({ ...parsed.flags }).toStrictEqual({});
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
 				i: [true, true, true],
 				n: [true],
 				v: [true],
@@ -154,7 +159,7 @@ describe('Parsing', () => {
 		test('Unknown flags starting with numbers', () => {
 			const parsed = typeFlag({}, ['--123abc', '--456', '-7', '-8a']);
 
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
 				'123abc': [true],
 				456: [true],
 				7: [true],
@@ -169,21 +174,21 @@ describe('Parsing', () => {
 			const argv = ['--retry', '-5'];
 			const parsed = typeFlag({ retry: Number }, argv);
 
-			expect<{ retry?: number }>(parsed.flags).toStrictEqual({ retry: -5 });
-			expect(parsed.unknownFlags).toStrictEqual({});
+			expect<{ retry?: number }>({ ...parsed.flags }).toStrictEqual({ retry: -5 });
+			expect({ ...parsed.unknownFlags }).toStrictEqual({});
 			expect<string[]>(argv).toStrictEqual([]);
 		});
 
 		test('consumes negative decimal', () => {
 			const parsed = typeFlag({ retry: Number }, ['--retry', '-5.5']);
 
-			expect<{ retry?: number }>(parsed.flags).toStrictEqual({ retry: -5.5 });
+			expect<{ retry?: number }>({ ...parsed.flags }).toStrictEqual({ retry: -5.5 });
 		});
 
 		test('consumes negative scientific notation', () => {
 			const parsed = typeFlag({ retry: Number }, ['--retry', '-5e3']);
 
-			expect<{ retry?: number }>(parsed.flags).toStrictEqual({ retry: -5000 });
+			expect<{ retry?: number }>({ ...parsed.flags }).toStrictEqual({ retry: -5000 });
 		});
 
 		test('consumes negative via alias', () => {
@@ -194,25 +199,25 @@ describe('Parsing', () => {
 				},
 			}, ['-r', '-5']);
 
-			expect<{ retry?: number }>(parsed.flags).toStrictEqual({ retry: -5 });
+			expect<{ retry?: number }>({ ...parsed.flags }).toStrictEqual({ retry: -5 });
 		});
 
 		test('explicit = value still works', () => {
 			const parsed = typeFlag({ retry: Number }, ['--retry=-5']);
 
-			expect<{ retry?: number }>(parsed.flags).toStrictEqual({ retry: -5 });
+			expect<{ retry?: number }>({ ...parsed.flags }).toStrictEqual({ retry: -5 });
 		});
 
 		test('string flag consumes negative-number token', () => {
 			const parsed = typeFlag({ name: String }, ['--name', '-5']);
 
-			expect<{ name?: string }>(parsed.flags).toStrictEqual({ name: '-5' });
+			expect<{ name?: string }>({ ...parsed.flags }).toStrictEqual({ name: '-5' });
 		});
 
 		test('array of numbers consumes negatives', () => {
 			const parsed = typeFlag({ nums: [Number] }, ['--nums', '-1', '--nums', '-2']);
 
-			expect<{ nums: number[] }>(parsed.flags).toStrictEqual({ nums: [-1, -2] });
+			expect<{ nums: number[] }>({ ...parsed.flags }).toStrictEqual({ nums: [-1, -2] });
 		});
 
 		describe('defined flags take precedence', () => {
@@ -229,12 +234,12 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-5']);
 
-				expect(parsed.flags).toStrictEqual({
+				expect({ ...parsed.flags }).toStrictEqual({
 					retry: Number.NaN,
 					fast: true,
 					name: undefined,
 				});
-				expect(parsed.unknownFlags).toStrictEqual({});
+				expect({ ...parsed.unknownFlags }).toStrictEqual({});
 			});
 
 			test('-5 then -n value', () => {
@@ -250,7 +255,7 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-5', '-n', 'Hiroki']);
 
-				expect(parsed.flags).toStrictEqual({
+				expect({ ...parsed.flags }).toStrictEqual({
 					retry: Number.NaN,
 					fast: true,
 					name: 'Hiroki',
@@ -270,7 +275,7 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-5n', 'Hiroki']);
 
-				expect(parsed.flags).toStrictEqual({
+				expect({ ...parsed.flags }).toStrictEqual({
 					retry: Number.NaN,
 					fast: true,
 					name: 'Hiroki',
@@ -290,7 +295,7 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-50']);
 
-				expect(parsed.flags).toStrictEqual({
+				expect({ ...parsed.flags }).toStrictEqual({
 					retry: -50,
 					fast: undefined,
 					name: undefined,
@@ -310,7 +315,7 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-5.5']);
 
-				expect(parsed.flags).toStrictEqual({
+				expect({ ...parsed.flags }).toStrictEqual({
 					retry: -5.5,
 					fast: undefined,
 					name: undefined,
@@ -334,7 +339,7 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-512']);
 
-				expect(parsed.flags).toStrictEqual({
+				expect({ ...parsed.flags }).toStrictEqual({
 					retry: Number.NaN,
 					alpha: true,
 					beta: true,
@@ -353,7 +358,7 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-5']);
 
-				expect(parsed.flags).toStrictEqual({
+				expect({ ...parsed.flags }).toStrictEqual({
 					retry: -5,
 					one: undefined,
 				});
@@ -368,7 +373,7 @@ describe('Parsing', () => {
 					},
 				}, ['-1']);
 
-				expect(parsed.flags).toStrictEqual({
+				expect({ ...parsed.flags }).toStrictEqual({
 					retry: undefined,
 					one: true,
 				});
@@ -383,7 +388,7 @@ describe('Parsing', () => {
 					},
 				}, ['-1', '--retry', '-5']);
 
-				expect(parsed.flags).toStrictEqual({
+				expect({ ...parsed.flags }).toStrictEqual({
 					retry: -5,
 					one: true,
 				});
@@ -398,7 +403,7 @@ describe('Parsing', () => {
 					},
 				}, ['--retry', '-1']);
 
-				expect(parsed.flags).toStrictEqual({
+				expect({ ...parsed.flags }).toStrictEqual({
 					retry: Number.NaN,
 					one: true,
 				});
@@ -409,22 +414,22 @@ describe('Parsing', () => {
 			test('standalone negative is an unknown flag', () => {
 				const parsed = typeFlag({ retry: Number }, ['-7']);
 
-				expect(parsed.flags).toStrictEqual({ retry: undefined });
-				expect(parsed.unknownFlags).toStrictEqual({ 7: [true] });
+				expect({ ...parsed.flags }).toStrictEqual({ retry: undefined });
+				expect({ ...parsed.unknownFlags }).toStrictEqual({ 7: [true] });
 			});
 
 			test('boolean flag does not consume a following negative', () => {
 				const parsed = typeFlag({ verbose: Boolean }, ['--verbose', '-5']);
 
-				expect(parsed.flags).toStrictEqual({ verbose: true });
-				expect(parsed.unknownFlags).toStrictEqual({ 5: [true] });
+				expect({ ...parsed.flags }).toStrictEqual({ verbose: true });
+				expect({ ...parsed.unknownFlags }).toStrictEqual({ 5: [true] });
 			});
 
 			test('array consumes one value; trailing negative is an unknown flag', () => {
 				const parsed = typeFlag({ nums: [Number] }, ['--nums', '-1', '-2']);
 
-				expect(parsed.flags).toStrictEqual({ nums: [-1] });
-				expect(parsed.unknownFlags).toStrictEqual({ 2: [true] });
+				expect({ ...parsed.flags }).toStrictEqual({ nums: [-1] });
+				expect({ ...parsed.unknownFlags }).toStrictEqual({ 2: [true] });
 			});
 		});
 
@@ -432,7 +437,7 @@ describe('Parsing', () => {
 			const argv = ['--retry', '--', '-5'];
 			const parsed = typeFlag({ retry: Number }, argv);
 
-			expect<{ retry?: number }>(parsed.flags).toStrictEqual({ retry: Number.NaN });
+			expect<{ retry?: number }>({ ...parsed.flags }).toStrictEqual({ retry: Number.NaN });
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(
 				Object.assign(['-5'], { '--': ['-5'] }),
 			);
@@ -898,7 +903,7 @@ describe('Parsing', () => {
 			}, ['-ab']);
 			expect<boolean | undefined>(parsed.flags.a).toBe(true);
 			expect<boolean | undefined>(parsed.flags.b).toBe(true);
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({});
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({});
 		});
 
 		test('groups three single-char boolean names', () => {
@@ -910,7 +915,7 @@ describe('Parsing', () => {
 			expect<boolean | undefined>(parsed.flags.a).toBe(true);
 			expect<boolean | undefined>(parsed.flags.b).toBe(true);
 			expect<boolean | undefined>(parsed.flags.c).toBe(true);
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({});
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({});
 		});
 
 		test('last char in group takes next-arg value', () => {
@@ -934,7 +939,7 @@ describe('Parsing', () => {
 		test('unknown char in group goes to unknownFlags, known chars still set', () => {
 			const parsed = typeFlag({ a: Boolean }, ['-ab']);
 			expect<boolean | undefined>(parsed.flags.a).toBe(true);
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
 				b: [true],
 			});
 		});
@@ -1123,7 +1128,7 @@ describe('Parsing', () => {
 
 			expect<boolean | undefined>(parsed.flags.alpha).toBe(true);
 			expect<boolean | undefined>(parsed.flags.gamma).toBe(true);
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
 				x: [true],
 			});
 			expect<string[]>(argv).toStrictEqual([]);
@@ -1154,13 +1159,13 @@ describe('Parsing', () => {
 
 		expect<{
 			[flag: string]: never;
-		}>(parsed.flags).toStrictEqual({});
+		}>({ ...parsed.flags }).toStrictEqual({});
 
 		type UnknownFlags = {
 			[flag: string]: (boolean | string)[];
 		};
 
-		expect<UnknownFlags>(parsed.unknownFlags).toStrictEqual({
+		expect<UnknownFlags>({ ...parsed.unknownFlags }).toStrictEqual({
 			unknownFlag: [true, 'false', ''],
 			u: [true, 'value'],
 			3: [true],
@@ -1195,10 +1200,10 @@ describe('Parsing', () => {
 				},
 			);
 
-			expect<{ string: string[] }>(parsed.flags).toStrictEqual({
+			expect<{ string: string[] }>({ ...parsed.flags }).toStrictEqual({
 				string: [],
 			});
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
 				unknown: [true, 'd'],
 				u: [true],
 				v: [true, true, '1'],
@@ -1230,11 +1235,11 @@ describe('Parsing', () => {
 			);
 
 			expect<{ string: string[];
-				boolean: boolean | undefined; }>(parsed.flags).toStrictEqual({
+				boolean: boolean | undefined; }>({ ...parsed.flags }).toStrictEqual({
 				string: ['a', 'b', 'd'],
 				boolean: true,
 			});
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({});
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({});
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(Object.assign(
 				['c'],
 				{ '--': [] },
@@ -1266,10 +1271,10 @@ describe('Parsing', () => {
 				},
 			);
 
-			expect<{ string: string[] }>(parsed.flags).toStrictEqual({
+			expect<{ string: string[] }>({ ...parsed.flags }).toStrictEqual({
 				string: ['value'],
 			});
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({});
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({});
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(Object.assign(
 				[],
 				{ '--': [] },
@@ -1297,11 +1302,11 @@ describe('Parsing', () => {
 			);
 
 			expect<{ string: string | undefined;
-				boolean: boolean | undefined; }>(parsed.flags).toStrictEqual({
+				boolean: boolean | undefined; }>({ ...parsed.flags }).toStrictEqual({
 				string: 'hello',
 				boolean: undefined,
 			});
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({});
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({});
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(Object.assign(
 				['a'],
 				{ '--': [] },
@@ -1338,7 +1343,7 @@ describe('Parsing', () => {
 			);
 
 			expect<string | undefined>(parsed.flags.string).toBe(undefined);
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({});
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({});
 			expect<string[] & { '--': string[] }>(parsed._).toStrictEqual(
 				Object.assign(
 					[],
@@ -1451,7 +1456,7 @@ describe('Parsing', () => {
 
 			expect<boolean | undefined>(parsed.flags.verbose).toBe(false);
 			expect<number | undefined>(parsed.flags.count).toBe(undefined);
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
 				'no-count': [true],
 			});
 		});
@@ -1548,7 +1553,7 @@ describe('Parsing', () => {
 			}, ['--no-verbose']);
 
 			expect<boolean | undefined>(parsed.flags.verbose).toBe(undefined);
-			expect<Record<string, (string | boolean)[]>>(parsed.unknownFlags).toStrictEqual({
+			expect<Record<string, (string | boolean)[]>>({ ...parsed.unknownFlags }).toStrictEqual({
 				'no-verbose': [true],
 			});
 		});
@@ -1617,7 +1622,7 @@ describe('Parsing', () => {
 			);
 
 			// `flags` groups by name, losing the interleaving...
-			expect(parsed.flags).toStrictEqual({
+			expect({ ...parsed.flags }).toStrictEqual({
 				data: ['a', 'c'],
 				dataUrlencode: ['b'],
 			});


### PR DESCRIPTION
## Problem

The parsed result's `flags` and `unknownFlags` are objects keyed by flag name, built as plain `{}` objects. `unknownFlags` keys come straight from argv, so a flag named `--__proto__` corrupted the object:

```js
const parsed = typeFlag({}, ['--__proto__'])
parsed.unknownFlags            // {} — the flag silently vanishes
Object.getPrototypeOf(parsed.unknownFlags) // mutated, no longer Object.prototype
```

`unknownFlags[name] = []` invokes the inherited `__proto__` setter instead of creating a key. (Scoped to the returned object, not global `Object.prototype`, but the flag is dropped and the object's prototype is replaced.) Present since the 4.x line.

## Changes

Build `flags` and `unknownFlags` as null-prototype objects — matching Node's `util.parseArgs`, whose `values` is null-prototype for the same reason. A flag named `__proto__` is now a normal own key and the result can't be prototype-polluted:

```js
typeFlag({}, ['--__proto__', '--__proto__=x']).unknownFlags
// { __proto__: [true, 'x'] }  (own key; no pollution)
```

Both objects are treated consistently. `_` (an array) and `entries` (fixed-shape records) are unaffected — their argv-derived data lives in values, not keys, so there's no injection vector.

BREAKING CHANGE: `flags` and `unknownFlags` are now null-prototype objects. They no longer inherit from `Object.prototype`, so use `name in flags` or `Object.hasOwn(flags, name)` for membership checks. Prototype-sensitive deep-equality against a plain `{}` (e.g. `assert.deepStrictEqual`) will also differ.
