### PR TITLE
feat: add FlagParseError for flag-value parse failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,15 +441,22 @@ These are the supported delimiters; arbitrary delimiter characters are not treat
 
 #### Error Wrapping
 
-When a custom type parser throws, the error is wrapped in a `TypeError` whose message identifies the flag by name. The original error is preserved on `.cause`.
+When a custom type parser (or [Standard Schema](#standard-schema-zod-valibot-arktype)) throws, the error is wrapped in a `FlagParseError` whose message identifies the flag by name. The original error is preserved on `.cause`, and the flag name on `.flagName`.
+
+`FlagParseError extends TypeError`, so existing `instanceof TypeError` checks keep working while `instanceof FlagParseError` lets you handle a bad flag value precisely.
 
 ```ts
+import { typeFlag, FlagParseError } from 'type-flag'
+
 // $ node ./cli --size huge
 try {
     typeFlag({ size: Size })
-} catch {
-    // thrown TypeError message      => 'Flag "--size": Invalid size: "huge"'
-    // .cause.message                => 'Invalid size: "huge"'
+} catch (error) {
+    if (error instanceof FlagParseError) {
+        error.flagName // 'size'
+        error.message // 'Flag "--size": Invalid size: "huge"'
+        error.cause // the original thrown error
+    }
 }
 ```
 

--- a/skills/type-flag/SKILL.md
+++ b/skills/type-flag/SKILL.md
@@ -69,7 +69,7 @@ typeFlag({
 - Multiple values: wrap in `[schema]`, NOT `z.array(...)` (it validates a single token and throws).
 - Numbers: CLI values are strings, so coerce (`z.coerce.number()`).
 - Booleans: keep native `Boolean` (a schema loses `--no-` negation and short grouping).
-- Sync only: async schemas throw. A failed schema is wrapped as `Flag "--<name>": <message>` (original on `.cause`).
+- Sync only: async schemas throw. A failed schema throws `FlagParseError` as `Flag "--<name>": <message>` (original on `.cause`).
 
 ## Return shape
 
@@ -187,8 +187,8 @@ Same argv-mutation behavior as `typeFlag`.
 | `unknownFlags` keys are raw | NOT camelCased — so you can distinguish `--some-flag` from `--someFlag`. |
 | Reserved chars in names | `\s`, `.`, `:`, `=` forbidden in flag names (they're delimiters). |
 | kebab schema key | If schema key is `'some-flag'`, only `--some-flag` / `--someFlag` both map to it, but output key stays kebab. |
-| Default functions throw | A throwing `default: () => ...` propagates. |
-| Parser/schema errors wrap | A throwing parser (or failed schema) is wrapped in a `TypeError` as `Flag "--<name>": <message>`; the original is on `.cause`. |
+| Default functions throw | A throwing `default: () => ...` propagates raw (NOT a `FlagParseError`). |
+| Parser/schema errors wrap | A throwing parser (or failed schema) throws `FlagParseError` (extends `TypeError`) as `Flag "--<name>": <message>`, with `.flagName` and the original on `.cause`. Exported from `type-flag`. |
 
 ## Related
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { typeFlag } from './type-flag.ts';
 export { getFlag } from './get-flag.ts';
+export { FlagParseError } from './utils.ts';
 export type {
 	TypeFlag,
 	TypeFlagOptions,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,10 +79,33 @@ export const normalizeBoolean = <T>(
 	return value;
 };
 
+/**
+ * Thrown when a flag's parser/validator (a custom type function or a Standard
+ * Schema) rejects the value. Extends `TypeError` for backward compatibility, so
+ * `instanceof TypeError` keeps working while `instanceof FlagParseError` gives a
+ * precise handle. The original error is preserved on `cause`.
+ */
+export class FlagParseError extends TypeError {
+	/** The flag whose value failed to parse, without the `--` prefix (e.g. `sort`). */
+	flagName: string;
+
+	constructor(
+		flagName: string,
+		cause: unknown,
+	) {
+		super(
+			`Flag "--${flagName}": ${cause instanceof Error ? cause.message : cause}`,
+			{ cause },
+		);
+		this.name = 'FlagParseError';
+		this.flagName = flagName;
+	}
+}
+
 export const applyParser = (
 	typeFunction: TypeFunction,
 	value: unknown,
-	flagName?: string,
+	flagName: string,
 ) => {
 	if (typeof value === 'boolean') {
 		return value;
@@ -95,10 +118,7 @@ export const applyParser = (
 	try {
 		return typeFunction(value);
 	} catch (error) {
-		throw new TypeError(
-			`Flag "--${flagName}": ${error instanceof Error ? error.message : error}`,
-			{ cause: error },
-		);
+		throw new FlagParseError(flagName, error);
 	}
 };
 

--- a/tests/specs/standard-schema.ts
+++ b/tests/specs/standard-schema.ts
@@ -6,6 +6,7 @@ import { type } from 'arktype';
 import {
 	typeFlag,
 	getFlag,
+	FlagParseError,
 } from '#type-flag';
 import { isStandardSchema, type StandardSchemaV1 } from '#type-flag/internal';
 
@@ -30,8 +31,11 @@ describe('standard-schema', () => {
 				thrown = error;
 			}
 
-			// type-flag wraps the thrown message with the flag-name context
+			// type-flag wraps the thrown message with the flag-name context as a
+			// FlagParseError (still a TypeError for backward compatibility)
+			expect(thrown).toBeInstanceOf(FlagParseError);
 			expect(thrown).toBeInstanceOf(TypeError);
+			expect((thrown as FlagParseError).flagName).toBe('size');
 			expect((thrown as TypeError).message).toMatch('Flag "--size":');
 			expect((thrown as TypeError).message).toMatch('Invalid option');
 

--- a/tests/specs/type-flag/error-handling.ts
+++ b/tests/specs/type-flag/error-handling.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'manten';
-import { typeFlag } from '#type-flag';
+import { typeFlag, FlagParseError } from '#type-flag';
 
 describe('Error handling', () => {
 	describe('Invalid flag name', () => {
@@ -126,6 +126,28 @@ describe('Error handling', () => {
 			}).toThrow('Flag "--custom": Custom parse error');
 		});
 
+		test('Thrown error is a FlagParseError exposing the flag name', () => {
+			const ThrowingParser = (_value: string) => {
+				throw new Error('Custom parse error');
+			};
+
+			let thrown: unknown;
+			try {
+				typeFlag({
+					custom: ThrowingParser,
+				}, ['--custom', 'value']);
+			} catch (error) {
+				thrown = error;
+			}
+
+			expect(thrown).toBeInstanceOf(FlagParseError);
+			// Still a TypeError, so existing checks keep working
+			expect(thrown).toBeInstanceOf(TypeError);
+			expect((thrown as FlagParseError).name).toBe('FlagParseError');
+			expect((thrown as FlagParseError).flagName).toBe('custom');
+			expect((thrown as FlagParseError).message).toBe('Flag "--custom": Custom parse error');
+		});
+
 		test('Custom parser throws on specific value', () => {
 			const StrictNumber = (value: string) => {
 				const parsed = Number(value);
@@ -153,14 +175,17 @@ describe('Error handling', () => {
 					flag: ThrowingParser,
 				}, ['--flag', 'value']);
 			} catch (error) {
+				expect(error).toBeInstanceOf(FlagParseError);
 				expect(error).toBeInstanceOf(TypeError);
+				expect((error as FlagParseError).flagName).toBe('flag');
 				expect((error as TypeError).cause).toBe(original);
 			}
 		});
 	});
 
 	test('Default function throws error', () => {
-		expect(() => {
+		let thrown: unknown;
+		try {
 			typeFlag({
 				flag: {
 					type: String,
@@ -169,6 +194,13 @@ describe('Error handling', () => {
 					},
 				},
 			}, []);
-		}).toThrow('Default function error');
+		} catch (error) {
+			thrown = error;
+		}
+
+		// Default-factory failures are a developer/runtime bug, not flag-value
+		// validation, so they propagate raw — never wrapped as a FlagParseError.
+		expect(thrown).not.toBeInstanceOf(FlagParseError);
+		expect((thrown as Error).message).toBe('Default function error');
 	});
 });


### PR DESCRIPTION
## Problem

When a flag's parser or [Standard Schema](https://github.com/privatenumber/type-flag#standard-schema-zod-valibot-arktype) rejects a value, type-flag re-throws it as a generic `TypeError` whose only distinguishing mark is the message prefix `Flag "--<name>": …`. Consumers that want to handle "the user gave a bad flag value" have to **string-match the message** — e.g. cleye currently branches on `error.message.startsWith('Flag "')`, which also has to be careful not to swallow unrelated `TypeError`s (a throwing `default` factory).

## Changes

Add a typed `FlagParseError`, thrown when a flag's parser/validator throws:

```ts
import { typeFlag, FlagParseError } from 'type-flag'

try {
    typeFlag({ size: z.enum(['a', 'b']) }, ['--size', 'bad'])
} catch (error) {
    if (error instanceof FlagParseError) {
        error.flagName // 'size'
        error.message  // 'Flag "--size": …'
        error.cause    // the original thrown error (e.g. a ZodError)
    }
}
```

- **`extends TypeError`** — fully backward-compatible. Existing `instanceof TypeError` checks keep working, and the message + `.cause` are byte-identical to before. `instanceof FlagParseError` is the precise opt-in.
- Thrown only for flag-value parse failures (custom type functions and Standard Schema validation, which runs inside `applyParser`). Config errors (duplicate/invalid flag names) stay plain `Error`, and a throwing `default` factory still propagates raw — neither is a `FlagParseError`.
- `error.flagName` is the raw flag name (no `--`); `error.cause` is the original error.
- `applyParser`'s internal `flagName` param is tightened to `string` (both call sites already pass one), keeping `error.flagName: string`.

Exported from the package root (`type-flag`).
