### PR TITLE
ci: run tests on beta pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [develop]
   pull_request:
-    branches: [master, develop, next]
+    branches: [master, develop, next, beta]
 
 jobs:
   test:


### PR DESCRIPTION
## Problem

`test.yml` only runs on PRs targeting `master`, `develop`, and `next` — not `beta`. Since the 5.x work is developed via PRs into `beta`, those PRs get no type-check / build / test / lint gate (only the package-size report runs). Recent beta PRs (#79, #80) merged without the suite ever running in CI.

## Changes

Add `beta` to `pull_request.branches` so PRs into `beta` run the full Test workflow (type-check, build, `pnpm test` on current + Node 22.22.2, lint).

Note: for `pull_request` events GitHub uses the workflow from the base branch, so this PR itself won't run the new job — it takes effect for beta PRs opened after this merges.
